### PR TITLE
fix: resolve Phase 1 review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,5 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          DATABASE_URL: "postgresql://dummy:dummy@localhost:5432/dummy?sslmode=prefer"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:integration": "vitest run --dir tests/integration"
+    "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/scripts/sync-validators.ts
+++ b/scripts/sync-validators.ts
@@ -102,11 +102,14 @@ async function syncValidators(
 async function main() {
   console.log("[sync-validators] Starting...");
 
-  const hour = new Date().getUTCHours();
-  const forceDailySnapshot = hour === 0;
+  const now = new Date();
+  const hour = now.getUTCHours();
+  const minute = now.getUTCMinutes();
+  // Only trigger daily snapshot in the first 5-min window (00:00-00:04 UTC)
+  const forceDailySnapshot = hour === 0 && minute < 5;
 
   if (forceDailySnapshot) {
-    console.log("[sync-validators] Daily snapshot mode (00:xx UTC)");
+    console.log("[sync-validators] Daily snapshot mode (00:00 UTC)");
   }
 
   try {

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/db";
 import { withRateLimit, jsonResponse, serializeBigInt } from "@/lib/api-helpers";
 
-function formatStats(s: {
+interface StatsRow {
   totalValidators: number;
   activeValidators: number;
   totalStaked: string;
@@ -10,7 +10,9 @@ function formatStats(s: {
   blockHeight: bigint;
   avgBlockTime: number | null;
   timestamp: Date;
-}) {
+}
+
+function formatStats(s: StatsRow) {
   return {
     totalValidators: s.totalValidators,
     activeValidators: s.activeValidators,
@@ -30,18 +32,24 @@ export async function GET(request: NextRequest) {
     orderBy: { timestamp: "desc" },
   });
 
+  // Daily aggregate: one record per day (last entry of each day) for 90 days
+  // Uses Prisma raw query to GROUP BY date and pick max timestamp per day
   const ninetyDaysAgo = new Date();
   ninetyDaysAgo.setDate(ninetyDaysAgo.getDate() - 90);
 
-  const history = await prisma.networkStats.findMany({
-    where: { timestamp: { gte: ninetyDaysAgo } },
-    orderBy: { timestamp: "asc" },
-  });
+  const dailyHistory: StatsRow[] = await prisma.$queryRaw`
+    SELECT DISTINCT ON (DATE("timestamp"))
+      "totalValidators", "activeValidators", "totalStaked",
+      "bondedRatio", "blockHeight", "avgBlockTime", "timestamp"
+    FROM "NetworkStats"
+    WHERE "timestamp" >= ${ninetyDaysAgo}
+    ORDER BY DATE("timestamp") ASC, "timestamp" DESC
+  `;
 
   return jsonResponse(
     serializeBigInt({
       current: current ? formatStats(current) : null,
-      history: history.map(formatStats),
+      history: dailyHistory.map(formatStats),
     }),
     rl.headers,
   );

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -16,11 +16,23 @@ function createPrismaClient() {
 }
 
 const globalForPrisma = globalThis as unknown as {
-  prisma: ReturnType<typeof createPrismaClient> | undefined;
+  prisma: PrismaClient | undefined;
 };
 
-export const prisma = globalForPrisma.prisma ?? createPrismaClient();
-
-if (process.env.NODE_ENV !== "production") {
-  globalForPrisma.prisma = prisma;
+function getClient(): PrismaClient {
+  if (!globalForPrisma.prisma) {
+    globalForPrisma.prisma = createPrismaClient();
+  }
+  return globalForPrisma.prisma;
 }
+
+/**
+ * Lazy-initialized Prisma client.
+ * Does NOT throw at import-time — only when first DB call is made.
+ * This allows Next.js build to succeed without DATABASE_URL.
+ */
+export const prisma = new Proxy({} as PrismaClient, {
+  get(_target, prop) {
+    return Reflect.get(getClient(), prop);
+  },
+});

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+  test: {
+    include: ["tests/integration/**/*.test.ts"],
+    testTimeout: 30000,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- **fix(db):** Lazy-init Prisma client via Proxy — prevents `DATABASE_URL not set` throw at import-time, fixing CI build failure
- **fix(ci):** Add dummy `DATABASE_URL` env to build step as safety net
- **fix(sync):** Restrict daily snapshot to 00:00-00:04 UTC window (was triggering 12x/hour)
- **fix(test):** Add `vitest.integration.config.ts` so `npm run test:integration` discovers test files
- **fix(stats):** Use `DISTINCT ON` daily aggregate query — caps `/api/stats` history at ~90 rows instead of ~8640 raw records
- **infra:** `enforce_admins: true` — admin bypass disabled, CI must pass before merge

## Findings Addressed

| # | Severity | Finding | Fix |
|---|----------|---------|-----|
| 1 | HIGH | CI build fails (DATABASE_URL missing) | Lazy Proxy init + dummy env |
| 2 | HIGH | Daily snapshot fires 12x instead of 1x | `hour===0 && minute<5` guard |
| 3 | HIGH | `test:integration` finds no tests | Separate vitest config |
| 5 | MEDIUM | Stats payload bloats with raw records | Daily aggregate via SQL |

## Remaining (user action needed)

| # | Severity | Item | Action |
|---|----------|------|--------|
| 4 | MEDIUM | CRON_SECRET + APP_URL secrets missing | `gh secret set CRON_SECRET` / `APP_URL` |
| 6 | MEDIUM | No migration artifacts in repo | Run `prisma migrate dev` after Neon DB setup |
| 7 | LOW | README still Phase 0 level | Will update in Phase 2 prep |

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 42/42 passed
- [x] `npm run build` — success (no DATABASE_URL throw)
- [ ] CI pipeline passes on this PR
- [ ] `npm run test:integration` discovers chain tests