### PR TITLE
fix: harden param validation and batch validator sync

### DIFF
--- a/scripts/sync-validators.ts
+++ b/scripts/sync-validators.ts
@@ -9,6 +9,8 @@ interface SyncResult {
   duration: number;
 }
 
+const BATCH_SIZE = 50;
+
 async function syncValidators(
   forceDailySnapshot = false,
 ): Promise<SyncResult> {
@@ -27,66 +29,71 @@ async function syncValidators(
   let snapshotsCreated = 0;
   let newValidators = 0;
 
-  for (const val of validators) {
-    const commission = parseFloat(val.commission) || 0;
-    const prev = existingMap.get(val.operatorAddress);
-
-    const hasChanged =
-      !prev ||
-      prev.tokens !== val.tokens ||
-      prev.status !== val.status ||
-      prev.commission !== commission ||
-      prev.jailed !== val.jailed;
-
-    const shouldSnapshot = hasChanged || forceDailySnapshot;
-
-    let jailCount = prev?.jailCount ?? 0;
-    let lastJailedAt = prev?.lastJailedAt ?? null;
-    if (prev && !prev.jailed && val.jailed) {
-      jailCount += 1;
-      lastJailedAt = new Date();
-    }
-
-    if (!prev) newValidators++;
+  // Process in batches to reduce transaction overhead
+  for (let i = 0; i < validators.length; i += BATCH_SIZE) {
+    const batch = validators.slice(i, i + BATCH_SIZE);
 
     await prisma.$transaction(async (tx) => {
-      await tx.validator.upsert({
-        where: { id: val.operatorAddress },
-        create: {
-          id: val.operatorAddress,
-          moniker: val.moniker,
-          status: val.status,
-          tokens: val.tokens,
-          commission,
-          jailed: val.jailed,
-          votingPower: val.tokens,
-          jailCount,
-          lastJailedAt,
-        },
-        update: {
-          moniker: val.moniker,
-          status: val.status,
-          tokens: val.tokens,
-          commission,
-          jailed: val.jailed,
-          votingPower: val.tokens,
-          jailCount,
-          lastJailedAt,
-        },
-      });
+      for (const val of batch) {
+        const commission = parseFloat(val.commission) || 0;
+        const prev = existingMap.get(val.operatorAddress);
 
-      if (shouldSnapshot) {
-        await tx.validatorSnapshot.create({
-          data: {
-            validatorId: val.operatorAddress,
-            tokens: val.tokens,
+        const hasChanged =
+          !prev ||
+          prev.tokens !== val.tokens ||
+          prev.status !== val.status ||
+          prev.commission !== commission ||
+          prev.jailed !== val.jailed;
+
+        const shouldSnapshot = hasChanged || forceDailySnapshot;
+
+        let jailCount = prev?.jailCount ?? 0;
+        let lastJailedAt = prev?.lastJailedAt ?? null;
+        if (prev && !prev.jailed && val.jailed) {
+          jailCount += 1;
+          lastJailedAt = new Date();
+        }
+
+        if (!prev) newValidators++;
+
+        await tx.validator.upsert({
+          where: { id: val.operatorAddress },
+          create: {
+            id: val.operatorAddress,
+            moniker: val.moniker,
             status: val.status,
+            tokens: val.tokens,
             commission,
             jailed: val.jailed,
             votingPower: val.tokens,
+            jailCount,
+            lastJailedAt,
+          },
+          update: {
+            moniker: val.moniker,
+            status: val.status,
+            tokens: val.tokens,
+            commission,
+            jailed: val.jailed,
+            votingPower: val.tokens,
+            jailCount,
+            lastJailedAt,
           },
         });
-        snapshotsCreated++;
+
+        if (shouldSnapshot) {
+          await tx.validatorSnapshot.create({
+            data: {
+              validatorId: val.operatorAddress,
+              tokens: val.tokens,
+              status: val.status,
+              commission,
+              jailed: val.jailed,
+              votingPower: val.tokens,
+            },
+          });
+          snapshotsCreated++;
+        }
       }
     });
   }

--- a/src/lib/indexer/validators.ts
+++ b/src/lib/indexer/validators.ts
@@ -13,6 +13,8 @@ interface SyncResult {
   duration: number;
 }
 
+const BATCH_SIZE = 50;
+
 export async function syncValidators(
   options: SyncOptions = {},
 ): Promise<SyncResult> {
@@ -29,67 +31,72 @@ export async function syncValidators(
     let snapshotsCreated = 0;
     let newValidators = 0;
 
-    for (const val of validators) {
-      const commission = parseFloat(val.commission) || 0;
-      const prev = existingMap.get(val.operatorAddress);
-
-      const hasChanged =
-        !prev ||
-        prev.tokens !== val.tokens ||
-        prev.status !== val.status ||
-        prev.commission !== commission ||
-        prev.jailed !== val.jailed;
-
-      const shouldSnapshot = hasChanged || forceDailySnapshot;
-
-      // Detect new jailing
-      let jailCount = prev?.jailCount ?? 0;
-      let lastJailedAt = prev?.lastJailedAt ?? null;
-      if (prev && !prev.jailed && val.jailed) {
-        jailCount += 1;
-        lastJailedAt = new Date();
-      }
-
-      if (!prev) newValidators++;
+    // Process in batches to reduce transaction overhead
+    for (let i = 0; i < validators.length; i += BATCH_SIZE) {
+      const batch = validators.slice(i, i + BATCH_SIZE);
 
       await prisma.$transaction(async (tx) => {
-        await tx.validator.upsert({
-          where: { id: val.operatorAddress },
-          create: {
-            id: val.operatorAddress,
-            moniker: val.moniker,
-            status: val.status,
-            tokens: val.tokens,
-            commission,
-            jailed: val.jailed,
-            votingPower: val.tokens,
-            jailCount,
-            lastJailedAt,
-          },
-          update: {
-            moniker: val.moniker,
-            status: val.status,
-            tokens: val.tokens,
-            commission,
-            jailed: val.jailed,
-            votingPower: val.tokens,
-            jailCount,
-            lastJailedAt,
-          },
-        });
+        for (const val of batch) {
+          const commission = parseFloat(val.commission) || 0;
+          const prev = existingMap.get(val.operatorAddress);
 
-        if (shouldSnapshot) {
-          await tx.validatorSnapshot.create({
-            data: {
-              validatorId: val.operatorAddress,
-              tokens: val.tokens,
+          const hasChanged =
+            !prev ||
+            prev.tokens !== val.tokens ||
+            prev.status !== val.status ||
+            prev.commission !== commission ||
+            prev.jailed !== val.jailed;
+
+          const shouldSnapshot = hasChanged || forceDailySnapshot;
+
+          // Detect new jailing
+          let jailCount = prev?.jailCount ?? 0;
+          let lastJailedAt = prev?.lastJailedAt ?? null;
+          if (prev && !prev.jailed && val.jailed) {
+            jailCount += 1;
+            lastJailedAt = new Date();
+          }
+
+          if (!prev) newValidators++;
+
+          await tx.validator.upsert({
+            where: { id: val.operatorAddress },
+            create: {
+              id: val.operatorAddress,
+              moniker: val.moniker,
               status: val.status,
+              tokens: val.tokens,
               commission,
               jailed: val.jailed,
               votingPower: val.tokens,
+              jailCount,
+              lastJailedAt,
+            },
+            update: {
+              moniker: val.moniker,
+              status: val.status,
+              tokens: val.tokens,
+              commission,
+              jailed: val.jailed,
+              votingPower: val.tokens,
+              jailCount,
+              lastJailedAt,
             },
           });
-          snapshotsCreated++;
+
+          if (shouldSnapshot) {
+            await tx.validatorSnapshot.create({
+              data: {
+                validatorId: val.operatorAddress,
+                tokens: val.tokens,
+                status: val.status,
+                commission,
+                jailed: val.jailed,
+                votingPower: val.tokens,
+              },
+            });
+            snapshotsCreated++;
+          }
         }
       });
     }

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -5,8 +5,8 @@ export function parseIntParam(
   max: number,
 ): number {
   if (!value) return defaultValue;
-  const parsed = parseInt(value, 10);
-  if (isNaN(parsed)) return defaultValue;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) return defaultValue;
   return Math.min(Math.max(parsed, min), max);
 }
 

--- a/tests/unit/lib/validation.test.ts
+++ b/tests/unit/lib/validation.test.ts
@@ -30,6 +30,14 @@ describe("parseIntParam", () => {
   it("returns default for empty string", () => {
     expect(parseIntParam("", 10, 1, 100)).toBe(10);
   });
+
+  it("rejects trailing non-numeric characters", () => {
+    expect(parseIntParam("10abc", 10, 1, 100)).toBe(10);
+  });
+
+  it("rejects float strings", () => {
+    expect(parseIntParam("10.5", 10, 1, 100)).toBe(10);
+  });
 });
 
 describe("parseStringParam", () => {


### PR DESCRIPTION
## Summary
- **fix(validation):** `parseIntParam` artık `Number()` + `Number.isInteger()` kullanıyor — `"10abc"`, `"10.5"` gibi geçersiz değerleri reddeder
- **perf(indexer):** Validator sync'de 1-transaction-per-validator yerine 50'lik batch transaction — 1200+ validator ölçeğinde ~24x daha az transaction overhead

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 44/44 passed (+2 yeni test)
- [x] `npm run build` — success