### PR TITLE
fix: add cron secret guards and clean lint warnings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ CRON_SECRET="change-me-to-a-strong-random-string"
 # App
 NEXT_PUBLIC_APP_URL="http://localhost:3000"
 NODE_ENV="development"
+
+# GitHub Actions Cron (set as GitHub secret, not needed locally)
+# APP_URL="https://panoptes.vercel.app"

--- a/.github/workflows/cron-cleanup.yml
+++ b/.github/workflows/cron-cleanup.yml
@@ -14,6 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
+      - name: Validate secrets
+        run: |
+          if [ -z "${{ secrets.APP_URL }}" ] || [ -z "${{ secrets.CRON_SECRET }}" ]; then
+            echo "::error::APP_URL or CRON_SECRET secret is not configured. Skipping."
+            exit 1
+          fi
+
       - name: Trigger data cleanup
         run: |
           curl -sf -X POST "${{ secrets.APP_URL }}/api/cron/cleanup" \

--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -14,6 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
+      - name: Validate secrets
+        run: |
+          if [ -z "${{ secrets.APP_URL }}" ] || [ -z "${{ secrets.CRON_SECRET }}" ]; then
+            echo "::error::APP_URL or CRON_SECRET secret is not configured. Skipping."
+            exit 1
+          fi
+
       - name: Trigger health check
         run: |
           curl -sf -X POST "${{ secrets.APP_URL }}/api/cron/health" \

--- a/.github/workflows/cron-stats.yml
+++ b/.github/workflows/cron-stats.yml
@@ -14,6 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
+      - name: Validate secrets
+        run: |
+          if [ -z "${{ secrets.APP_URL }}" ] || [ -z "${{ secrets.CRON_SECRET }}" ]; then
+            echo "::error::APP_URL or CRON_SECRET secret is not configured. Skipping."
+            exit 1
+          fi
+
       - name: Trigger stats aggregation
         run: |
           curl -sf -X POST "${{ secrets.APP_URL }}/api/cron/stats" \

--- a/.github/workflows/cron-validators.yml
+++ b/.github/workflows/cron-validators.yml
@@ -14,6 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
+      - name: Validate secrets
+        run: |
+          if [ -z "${{ secrets.DATABASE_URL }}" ]; then
+            echo "::error::DATABASE_URL secret is not configured. Skipping."
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import "dotenv/config";
 import { neonConfig } from "@neondatabase/serverless";
 import { PrismaNeon } from "@prisma/adapter-neon";

--- a/scripts/sync-validators.ts
+++ b/scripts/sync-validators.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import "dotenv/config";
 import { prisma } from "./db.js";
 import { RepublicClient, REPUBLIC_TESTNET } from "republic-sdk";


### PR DESCRIPTION
## Summary
- **fix(cron):** All 4 cron workflows now validate required secrets before executing — fails fast with `::error::` annotation instead of cryptic curl/connection errors
- **chore(lint):** `eslint-disable no-console` added to `seed.ts` and `sync-validators.ts` — lint now passes with 0 warnings
- **docs:** `APP_URL` added to `.env.example`

## Test plan
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 44/44 passed
- [ ] CI green