### PR TITLE
fix(cron): use CRONS_ENABLED gate instead of fail-fast guard

### DIFF
--- a/.github/workflows/cron-cleanup.yml
+++ b/.github/workflows/cron-cleanup.yml
@@ -13,14 +13,8 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     timeout-minutes: 1
+    if: ${{ vars.CRONS_ENABLED == 'true' }}
     steps:
-      - name: Validate secrets
-        run: |
-          if [ -z "${{ secrets.APP_URL }}" ] || [ -z "${{ secrets.CRON_SECRET }}" ]; then
-            echo "::error::APP_URL or CRON_SECRET secret is not configured. Skipping."
-            exit 1
-          fi
-
       - name: Trigger data cleanup
         run: |
           curl -sf -X POST "${{ secrets.APP_URL }}/api/cron/cleanup" \

--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -13,14 +13,8 @@ jobs:
   health:
     runs-on: ubuntu-latest
     timeout-minutes: 1
+    if: ${{ vars.CRONS_ENABLED == 'true' }}
     steps:
-      - name: Validate secrets
-        run: |
-          if [ -z "${{ secrets.APP_URL }}" ] || [ -z "${{ secrets.CRON_SECRET }}" ]; then
-            echo "::error::APP_URL or CRON_SECRET secret is not configured. Skipping."
-            exit 1
-          fi
-
       - name: Trigger health check
         run: |
           curl -sf -X POST "${{ secrets.APP_URL }}/api/cron/health" \

--- a/.github/workflows/cron-stats.yml
+++ b/.github/workflows/cron-stats.yml
@@ -13,14 +13,8 @@ jobs:
   stats:
     runs-on: ubuntu-latest
     timeout-minutes: 1
+    if: ${{ vars.CRONS_ENABLED == 'true' }}
     steps:
-      - name: Validate secrets
-        run: |
-          if [ -z "${{ secrets.APP_URL }}" ] || [ -z "${{ secrets.CRON_SECRET }}" ]; then
-            echo "::error::APP_URL or CRON_SECRET secret is not configured. Skipping."
-            exit 1
-          fi
-
       - name: Trigger stats aggregation
         run: |
           curl -sf -X POST "${{ secrets.APP_URL }}/api/cron/stats" \

--- a/.github/workflows/cron-validators.yml
+++ b/.github/workflows/cron-validators.yml
@@ -13,14 +13,8 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    if: ${{ vars.CRONS_ENABLED == 'true' }}
     steps:
-      - name: Validate secrets
-        run: |
-          if [ -z "${{ secrets.DATABASE_URL }}" ]; then
-            echo "::error::DATABASE_URL secret is not configured. Skipping."
-            exit 1
-          fi
-
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Replace per-step secret validation with job-level `if: vars.CRONS_ENABLED == 'true'`
- Jobs now **skip silently** when crons are not enabled — repo stays green during pre-deploy phase
- Published v0.1.0 release (was draft)

## Activation
After DB + Vercel deploy:
```bash
gh variable set CRONS_ENABLED --body "true" --repo eren-karakus0/panoptes
```

## Test plan
- [x] Lint, tsc, tests all passing
- [ ] CI green
- [ ] Cron workflows show as "skipped" instead of "failed"