### PR TITLE
refactor(landing): unify plum palette + scroll flow + a11y

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -167,5 +167,21 @@ body {
   }
   html {
     @apply font-sans;
+    scroll-behavior: smooth;
+  }
+}
+
+.landing-gradient-glow {
+  background: radial-gradient(
+    ellipse 120% 80% at 50% 20%,
+    oklch(0.3 0.15 280 / 0.12) 0%,
+    oklch(0.2 0.1 280 / 0.06) 40%,
+    transparent 70%
+  );
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,13 +7,16 @@ import { CallToAction } from "@/components/landing/cta";
 
 export default function Home() {
   return (
-    <main className="min-h-screen">
-      <Hero />
-      <Features />
-      <NetworkStats />
-      <HowItWorks />
-      <ApiTeaser />
-      <CallToAction />
+    <main className="relative min-h-screen bg-midnight-plum">
+      <div className="landing-gradient-glow pointer-events-none fixed inset-0" />
+      <div className="relative">
+        <Hero />
+        <Features />
+        <NetworkStats />
+        <HowItWorks />
+        <ApiTeaser />
+        <CallToAction />
+      </div>
     </main>
   );
 }

--- a/src/components/landing/api-teaser.tsx
+++ b/src/components/landing/api-teaser.tsx
@@ -1,38 +1,64 @@
 "use client";
 
+import { useRef } from "react";
 import Link from "next/link";
+import { motion, useInView, useReducedMotion } from "motion/react";
 import { Code2, ExternalLink } from "lucide-react";
+import { codeLine } from "@/lib/animations";
 import { ScrollReveal } from "./scroll-reveal";
 
-const codeSnippet = `// Get the best RPC endpoint (score-weighted)
-const res = await fetch('/api/endpoints/best?type=rpc');
-const { endpoint, strategy } = await res.json();
-
-// Use with republic-sdk
-const client = await RepublicClient.connect({
-  rpcUrl: endpoint.url,
-});`;
+const codeLines = [
+  "// Get the best RPC endpoint (score-weighted)",
+  "const res = await fetch('/api/endpoints/best?type=rpc');",
+  "const { endpoint, strategy } = await res.json();",
+  "",
+  "// Use with republic-sdk",
+  "const client = await RepublicClient.connect({",
+  "  rpcUrl: endpoint.url,",
+  "});",
+];
 
 export function ApiTeaser() {
+  const codeRef = useRef<HTMLDivElement>(null);
+  const isInView = useInView(codeRef, { once: true, margin: "-80px" });
+  const prefersReduced = useReducedMotion();
+
   return (
-    <section className="bg-indigo-dark px-4 py-24 md:py-32">
-      <div className="mx-auto max-w-4xl">
+    <section className="bg-[#1a1230] px-4 py-24 md:py-32">
+      {/* Section separator */}
+      <div className="h-px bg-gradient-to-r from-transparent via-soft-violet/20 to-transparent" />
+
+      <div className="mx-auto max-w-4xl pt-8">
         <ScrollReveal>
           <div className="flex items-center justify-center gap-2">
-            <Code2 className="size-6 text-indigo-light" />
-            <h2 className="font-display text-3xl font-bold text-indigo-light md:text-4xl">
+            <Code2 className="size-6 text-soft-violet" />
+            <h2 className="font-display text-3xl font-bold text-soft-violet md:text-4xl">
               Developer-Friendly API
             </h2>
           </div>
-          <p className="mx-auto mt-4 max-w-2xl text-center text-mist/70">
+          <p className="mx-auto mt-4 max-w-2xl text-center text-dusty-lavender/70">
             Simple REST API for programmatic access to chain intelligence.
           </p>
         </ScrollReveal>
 
         <ScrollReveal delay={0.2}>
-          <div className="mt-12 overflow-x-auto rounded-xl border border-indigo-DEFAULT/30 bg-indigo-dark/50 p-6">
-            <pre className="font-mono text-xs leading-relaxed text-indigo-light md:text-sm">
-              <code>{codeSnippet}</code>
+          <div
+            ref={codeRef}
+            className="mt-12 overflow-x-auto rounded-xl border border-soft-violet/30 bg-deep-iris/10 p-6 backdrop-blur-sm shadow-lg shadow-soft-violet/5"
+          >
+            <pre className="font-mono text-xs leading-relaxed md:text-sm">
+              {codeLines.map((line, i) => (
+                <motion.code
+                  key={i}
+                  variants={prefersReduced ? undefined : codeLine}
+                  initial={prefersReduced ? undefined : "hidden"}
+                  animate={prefersReduced ? undefined : isInView ? "visible" : "hidden"}
+                  custom={i}
+                  className="block text-dusty-lavender"
+                >
+                  {line || "\u00A0"}
+                </motion.code>
+              ))}
             </pre>
           </div>
         </ScrollReveal>
@@ -40,7 +66,7 @@ export function ApiTeaser() {
         <ScrollReveal delay={0.3} className="mt-8 text-center">
           <Link
             href="/dashboard"
-            className="inline-flex items-center gap-2 rounded-lg border border-indigo-DEFAULT/30 px-6 py-3 text-sm font-medium text-indigo-light transition-colors hover:border-indigo-light hover:text-white"
+            className="inline-flex items-center gap-2 rounded-lg border border-soft-violet/30 px-6 py-3 text-sm font-medium text-soft-violet transition-all hover:scale-105 hover:border-soft-violet hover:bg-soft-violet/10"
           >
             Explore Dashboard
             <ExternalLink className="size-4" />

--- a/src/components/landing/cta.tsx
+++ b/src/components/landing/cta.tsx
@@ -4,21 +4,24 @@ import { APP_NAME, APP_VERSION } from "@/lib/constants";
 
 export function CallToAction() {
   return (
-    <section className="bg-amber-dark px-4 py-24 md:py-32">
-      <div className="mx-auto max-w-4xl">
+    <section className="bg-midnight-plum px-4 py-24 md:py-32">
+      {/* Section separator */}
+      <div className="h-px bg-gradient-to-r from-transparent via-soft-violet/20 to-transparent" />
+
+      <div className="mx-auto max-w-4xl pt-8">
         {/* CTA */}
         <div className="text-center">
-          <h2 className="font-display text-3xl font-bold text-amber-light md:text-4xl">
+          <h2 className="font-display text-3xl font-bold text-soft-violet md:text-4xl">
             Start Monitoring Now
           </h2>
-          <p className="mx-auto mt-4 max-w-lg text-mist/70">
+          <p className="mx-auto mt-4 max-w-lg text-dusty-lavender/70">
             Get real-time insights into the Republic AI network. Track
             validators, score endpoints, and route intelligently.
           </p>
           <div className="mt-8 flex flex-wrap justify-center gap-4">
             <Link
               href="/dashboard"
-              className="rounded-lg bg-amber-DEFAULT px-6 py-3 text-sm font-bold text-amber-dark transition-colors hover:bg-amber-light"
+              className="rounded-lg bg-soft-violet px-6 py-3 text-sm font-bold text-white transition-all hover:bg-deep-iris hover:scale-105 hover:shadow-lg hover:shadow-soft-violet/20"
             >
               Open Dashboard
             </Link>
@@ -26,7 +29,7 @@ export function CallToAction() {
               href="https://discord.gg/kNERz4xC"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 rounded-lg border border-amber-DEFAULT/30 px-6 py-3 text-sm font-medium text-amber-light transition-colors hover:border-amber-light"
+              className="inline-flex items-center gap-2 rounded-lg border border-soft-violet/30 px-6 py-3 text-sm font-medium text-dusty-lavender transition-all hover:scale-105 hover:border-soft-violet hover:bg-soft-violet/10"
             >
               <MessageCircle className="size-4" />
               Join Discord
@@ -35,11 +38,11 @@ export function CallToAction() {
         </div>
 
         {/* Footer */}
-        <footer className="mt-20 border-t border-amber-DEFAULT/30 pt-8">
+        <footer className="mt-20 border-t border-soft-violet/20 pt-8">
           <div className="flex flex-col items-center gap-6 md:flex-row md:justify-between">
             {/* Left */}
             <div className="flex items-center gap-3 text-sm text-mist/50">
-              <span className="rounded-md bg-amber-DEFAULT/20 px-2 py-0.5 text-xs font-medium text-amber-light">
+              <span className="rounded-md bg-soft-violet/15 px-2 py-0.5 text-xs font-medium text-dusty-lavender">
                 v{APP_VERSION}
               </span>
               <span>MIT License</span>
@@ -51,7 +54,7 @@ export function CallToAction() {
                 href="https://github.com/eren-karakus0/panoptes"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-mist/50 transition-colors hover:text-amber-light"
+                className="text-mist/50 transition-colors hover:text-soft-violet"
                 aria-label="GitHub"
               >
                 <Github className="size-5" />
@@ -60,7 +63,7 @@ export function CallToAction() {
                 href="https://discord.gg/kNERz4xC"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-mist/50 transition-colors hover:text-amber-light"
+                className="text-mist/50 transition-colors hover:text-soft-violet"
                 aria-label="Discord"
               >
                 <MessageCircle className="size-5" />
@@ -74,7 +77,7 @@ export function CallToAction() {
                 href="https://www.npmjs.com/package/republic-sdk"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-amber-light/70 transition-colors hover:text-amber-light"
+                className="text-soft-violet/70 transition-colors hover:text-soft-violet"
               >
                 republic-sdk
               </a>

--- a/src/components/landing/features.tsx
+++ b/src/components/landing/features.tsx
@@ -18,48 +18,63 @@ const features = [
     title: "Validator Monitoring",
     description:
       "Real-time tracking with historical snapshots and stake change detection.",
+    iconColor: "text-teal-light",
+    iconBg: "bg-teal-DEFAULT/20",
   },
   {
     icon: Gauge,
     title: "Endpoint Health",
     description:
       "Continuous health checks. Track latency, uptime, and block freshness.",
+    iconColor: "text-teal-light",
+    iconBg: "bg-teal-DEFAULT/20",
   },
   {
     icon: Brain,
     title: "Intelligence Layer",
     description:
       "Composite scoring with EMA smoothing for validators and endpoints.",
+    iconColor: "text-soft-violet",
+    iconBg: "bg-soft-violet/15",
   },
   {
     icon: Route,
     title: "Smart Routing",
     description:
       "Score-weighted endpoint selection with quadratic bias.",
+    iconColor: "text-soft-violet",
+    iconBg: "bg-soft-violet/15",
   },
   {
     icon: ShieldCheck,
     title: "Preflight Validation",
     description:
       "6-step pre-transaction validation with timeout protection.",
+    iconColor: "text-soft-violet",
+    iconBg: "bg-soft-violet/15",
   },
   {
     icon: Zap,
     title: "Anomaly Detection",
     description:
       "6 detectors for jailing, stake spikes, commission changes, downtime.",
+    iconColor: "text-amber-light",
+    iconBg: "bg-amber-DEFAULT/20",
   },
 ] as const;
 
 export function Features() {
   return (
-    <section className="bg-teal-dark px-4 py-24 md:py-32">
-      <div className="mx-auto max-w-6xl">
-        <ScrollReveal>
-          <h2 className="text-center font-display text-3xl font-bold text-teal-light md:text-4xl">
+    <section className="bg-midnight-plum px-4 py-24 md:py-32">
+      {/* Section separator */}
+      <div className="h-px bg-gradient-to-r from-transparent via-soft-violet/20 to-transparent" />
+
+      <div className="mx-auto max-w-6xl pt-8">
+        <ScrollReveal margin="-120px">
+          <h2 className="text-center font-display text-3xl font-bold text-soft-violet md:text-4xl">
             Comprehensive Chain Intelligence
           </h2>
-          <p className="mx-auto mt-4 max-w-2xl text-center text-mist/70">
+          <p className="mx-auto mt-4 max-w-2xl text-center text-dusty-lavender/70">
             Everything you need to monitor, score, and interact with the
             Republic AI network.
           </p>
@@ -67,21 +82,22 @@ export function Features() {
 
         <ScrollReveal
           stagger
+          margin="-120px"
           className="mt-16 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3"
         >
           {features.map((feature) => (
             <motion.div
               key={feature.title}
               variants={staggerItem}
-              className="rounded-xl border border-teal-DEFAULT/30 bg-teal-dark/50 p-6 transition-colors hover:border-teal-DEFAULT"
+              className="group rounded-xl border border-soft-violet/20 bg-deep-iris/10 p-6 backdrop-blur-sm transition-all hover:border-soft-violet/30 hover:bg-deep-iris/15 hover:shadow-lg hover:shadow-soft-violet/5"
             >
-              <div className="flex size-10 items-center justify-center rounded-full bg-teal-DEFAULT/20">
-                <feature.icon className="size-5 text-teal-light" />
+              <div className={`flex size-10 items-center justify-center rounded-full ${feature.iconBg} transition-transform group-hover:scale-110`}>
+                <feature.icon className={`size-5 ${feature.iconColor}`} />
               </div>
-              <h3 className="mt-4 font-display text-lg font-semibold text-teal-light">
+              <h3 className="mt-4 font-display text-lg font-semibold text-dusty-lavender">
                 {feature.title}
               </h3>
-              <p className="mt-2 text-sm text-mist/70">
+              <p className="mt-2 text-sm text-dusty-lavender/70">
                 {feature.description}
               </p>
             </motion.div>

--- a/src/components/landing/hero.tsx
+++ b/src/components/landing/hero.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { motion } from "motion/react";
+import { motion, useReducedMotion, useScroll, useTransform } from "motion/react";
 import { ChevronDown, Github } from "lucide-react";
 import { APP_NAME, APP_TAGLINE, APP_DESCRIPTION } from "@/lib/constants";
 import { fadeInUp, floatingParticle } from "@/lib/animations";
@@ -10,117 +11,136 @@ import { fadeInUp, floatingParticle } from "@/lib/animations";
 const particles = Array.from({ length: 7 }, (_, i) => i);
 
 export function Hero() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const prefersReduced = useReducedMotion();
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ["start start", "end start"],
+  });
+  const contentY = useTransform(scrollYProgress, [0, 1], [0, prefersReduced ? 0 : 150]);
+  const glowOpacity = useTransform(scrollYProgress, [0, 0.5, 1], prefersReduced ? [1, 1, 1] : [1, 0.8, 0]);
+
   return (
-    <section className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-midnight-plum px-4 text-center">
+    <section
+      ref={sectionRef}
+      className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden bg-midnight-plum px-4 text-center"
+    >
       {/* Radial gradient glow */}
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,_var(--color-deep-iris)/10_0%,_transparent_70%)]" />
+      <motion.div
+        style={{ opacity: glowOpacity }}
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,_var(--color-deep-iris)/10_0%,_transparent_70%)]"
+      />
 
-      {/* Floating particles */}
-      {particles.map((i) => (
+      {/* Floating particles — skip when reduced motion */}
+      {!prefersReduced &&
+        particles.map((i) => (
+          <motion.div
+            key={i}
+            variants={floatingParticle}
+            initial="initial"
+            animate="animate"
+            custom={i}
+            className="absolute rounded-full bg-soft-violet/20"
+            style={{
+              width: 6 + i * 3,
+              height: 6 + i * 3,
+              left: `${10 + i * 12}%`,
+              top: `${20 + (i % 3) * 25}%`,
+            }}
+          />
+        ))}
+
+      {/* Content with parallax */}
+      <motion.div style={{ y: contentY }} className="relative z-10 space-y-8">
         <motion.div
-          key={i}
-          variants={floatingParticle}
-          initial="initial"
-          animate="animate"
-          custom={i}
-          className="absolute rounded-full bg-soft-violet/20"
-          style={{
-            width: 6 + i * 3,
-            height: 6 + i * 3,
-            left: `${10 + i * 12}%`,
-            top: `${20 + (i % 3) * 25}%`,
-          }}
-        />
-      ))}
-
-      {/* Content */}
-      <motion.div
-        variants={fadeInUp}
-        initial="hidden"
-        animate="visible"
-        custom={0}
-        className="relative z-10"
-      >
-        <Image
-          src="/logo.svg"
-          alt={`${APP_NAME} logo`}
-          width={120}
-          height={120}
-          className="mx-auto h-20 w-20 md:h-[100px] md:w-[100px] lg:h-[120px] lg:w-[120px]"
-          priority
-        />
-      </motion.div>
-
-      <motion.h1
-        variants={fadeInUp}
-        initial="hidden"
-        animate="visible"
-        custom={0.1}
-        className="relative z-10 mt-8 font-display text-5xl font-bold tracking-tight md:text-6xl lg:text-7xl"
-      >
-        <span className="bg-gradient-to-r from-soft-violet to-dusty-lavender bg-clip-text text-transparent">
-          {APP_NAME}
-        </span>
-      </motion.h1>
-
-      <motion.p
-        variants={fadeInUp}
-        initial="hidden"
-        animate="visible"
-        custom={0.2}
-        className="relative z-10 mt-4 font-display text-lg text-dusty-lavender md:text-xl"
-      >
-        {APP_TAGLINE}
-      </motion.p>
-
-      <motion.p
-        variants={fadeInUp}
-        initial="hidden"
-        animate="visible"
-        custom={0.3}
-        className="relative z-10 mt-6 max-w-lg text-sm text-mist/70"
-      >
-        {APP_DESCRIPTION}
-      </motion.p>
-
-      <motion.div
-        variants={fadeInUp}
-        initial="hidden"
-        animate="visible"
-        custom={0.4}
-        className="relative z-10 mt-10 flex gap-4"
-      >
-        <Link
-          href="/dashboard"
-          className="rounded-lg bg-soft-violet px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-deep-iris"
+          variants={fadeInUp}
+          initial="hidden"
+          animate="visible"
+          custom={0}
         >
-          View Dashboard
-        </Link>
-        <a
-          href="https://github.com/eren-karakus0/panoptes"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 rounded-lg border border-dusty-lavender/30 px-6 py-3 text-sm font-medium text-dusty-lavender transition-colors hover:border-soft-violet hover:text-soft-violet"
+          <Image
+            src="/logo.svg"
+            alt={`${APP_NAME} logo`}
+            width={120}
+            height={120}
+            className="mx-auto h-20 w-20 md:h-[100px] md:w-[100px] lg:h-[120px] lg:w-[120px]"
+            priority
+          />
+        </motion.div>
+
+        <motion.h1
+          variants={fadeInUp}
+          initial="hidden"
+          animate="visible"
+          custom={0.1}
+          className="font-display text-5xl font-bold tracking-tight md:text-6xl lg:text-7xl"
         >
-          <Github className="size-4" />
-          GitHub
-        </a>
+          <span className="bg-gradient-to-r from-soft-violet to-dusty-lavender bg-clip-text text-transparent">
+            {APP_NAME}
+          </span>
+        </motion.h1>
+
+        <motion.p
+          variants={fadeInUp}
+          initial="hidden"
+          animate="visible"
+          custom={0.2}
+          className="font-display text-lg text-dusty-lavender md:text-xl"
+        >
+          {APP_TAGLINE}
+        </motion.p>
+
+        <motion.p
+          variants={fadeInUp}
+          initial="hidden"
+          animate="visible"
+          custom={0.3}
+          className="mx-auto max-w-lg text-sm text-mist/70"
+        >
+          {APP_DESCRIPTION}
+        </motion.p>
+
+        <motion.div
+          variants={fadeInUp}
+          initial="hidden"
+          animate="visible"
+          custom={0.4}
+          className="flex justify-center gap-4"
+        >
+          <Link
+            href="/dashboard"
+            className="rounded-lg bg-soft-violet px-6 py-3 text-sm font-medium text-white transition-all hover:bg-deep-iris hover:scale-105 hover:shadow-lg hover:shadow-soft-violet/20"
+          >
+            View Dashboard
+          </Link>
+          <a
+            href="https://github.com/eren-karakus0/panoptes"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-dusty-lavender/30 px-6 py-3 text-sm font-medium text-dusty-lavender transition-all hover:border-soft-violet hover:text-soft-violet hover:scale-105 hover:shadow-lg hover:shadow-soft-violet/20"
+          >
+            <Github className="size-4" />
+            GitHub
+          </a>
+        </motion.div>
       </motion.div>
 
       {/* Scroll indicator */}
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ delay: 1, duration: 0.5 }}
-        className="absolute bottom-8 z-10"
-      >
+      {!prefersReduced && (
         <motion.div
-          animate={{ y: [0, 8, 0] }}
-          transition={{ duration: 1.5, repeat: Infinity, ease: "easeInOut" }}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 1, duration: 0.5 }}
+          className="absolute bottom-8 z-10"
         >
-          <ChevronDown className="size-6 text-dusty-lavender/50" />
+          <motion.div
+            animate={{ y: [0, 8, 0] }}
+            transition={{ duration: 1.5, repeat: Infinity, ease: "easeInOut" }}
+          >
+            <ChevronDown className="size-6 text-dusty-lavender/50" />
+          </motion.div>
         </motion.div>
-      </motion.div>
+      )}
     </section>
   );
 }

--- a/src/components/landing/how-it-works.tsx
+++ b/src/components/landing/how-it-works.tsx
@@ -28,13 +28,16 @@ const steps = [
 
 export function HowItWorks() {
   return (
-    <section className="bg-rose-dark px-4 py-24 md:py-32">
-      <div className="mx-auto max-w-5xl">
-        <ScrollReveal>
-          <h2 className="text-center font-display text-3xl font-bold text-rose-light md:text-4xl">
+    <section className="bg-midnight-plum px-4 py-24 md:py-32">
+      {/* Section separator */}
+      <div className="h-px bg-gradient-to-r from-transparent via-soft-violet/20 to-transparent" />
+
+      <div className="mx-auto max-w-5xl pt-8">
+        <ScrollReveal margin="-120px">
+          <h2 className="text-center font-display text-3xl font-bold text-soft-violet md:text-4xl">
             How It Works
           </h2>
-          <p className="mx-auto mt-4 max-w-2xl text-center text-mist/70">
+          <p className="mx-auto mt-4 max-w-2xl text-center text-dusty-lavender/70">
             Three-stage pipeline for chain intelligence.
           </p>
         </ScrollReveal>
@@ -43,9 +46,9 @@ export function HowItWorks() {
           {/* Connection lines — desktop only */}
           <div className="pointer-events-none absolute inset-0 hidden items-center md:flex">
             <div className="mx-auto flex w-full max-w-3xl justify-between px-20">
-              <div className="h-px flex-1 bg-gradient-to-r from-rose-DEFAULT to-transparent" />
+              <div className="h-px flex-1 bg-gradient-to-r from-soft-violet/40 to-transparent" />
               <div className="w-16" />
-              <div className="h-px flex-1 bg-gradient-to-r from-rose-DEFAULT to-transparent" />
+              <div className="h-px flex-1 bg-gradient-to-r from-soft-violet/40 to-transparent" />
             </div>
           </div>
 
@@ -54,18 +57,18 @@ export function HowItWorks() {
               <motion.div
                 key={step.title}
                 variants={staggerItem}
-                className="flex flex-col items-center text-center"
+                className="group flex flex-col items-center text-center"
               >
-                <div className="relative flex size-16 items-center justify-center rounded-full bg-rose-DEFAULT/20">
-                  <step.icon className="size-8 text-rose-light" />
-                  <span className="absolute -right-1 -top-1 flex size-6 items-center justify-center rounded-full bg-rose-DEFAULT text-xs font-bold text-white">
+                <div className="relative flex size-16 items-center justify-center rounded-full bg-soft-violet/15 ring-2 ring-soft-violet/30 transition-all group-hover:ring-soft-violet/50 group-hover:scale-110">
+                  <step.icon className="size-8 text-soft-violet" />
+                  <span className="absolute -right-1 -top-1 flex size-6 items-center justify-center rounded-full bg-soft-violet text-xs font-bold text-white shadow-lg shadow-soft-violet/30">
                     {i + 1}
                   </span>
                 </div>
-                <h3 className="mt-6 font-display text-xl font-semibold text-rose-light">
+                <h3 className="mt-6 font-display text-xl font-semibold text-dusty-lavender">
                   {step.title}
                 </h3>
-                <p className="mt-2 max-w-xs text-sm text-mist/70">
+                <p className="mt-2 max-w-xs text-sm text-dusty-lavender/70">
                   {step.description}
                 </p>
               </motion.div>

--- a/src/components/landing/network-stats.tsx
+++ b/src/components/landing/network-stats.tsx
@@ -79,13 +79,16 @@ export function NetworkStats() {
   ];
 
   return (
-    <section className="bg-slate-dark px-4 py-24 md:py-32">
-      <div className="mx-auto max-w-6xl">
-        <ScrollReveal>
-          <h2 className="text-center font-display text-3xl font-bold text-slate-light md:text-4xl">
+    <section className="bg-[#1a1230] px-4 py-24 md:py-32">
+      {/* Section separator */}
+      <div className="h-px bg-gradient-to-r from-transparent via-soft-violet/20 to-transparent" />
+
+      <div className="mx-auto max-w-6xl pt-8">
+        <ScrollReveal margin="-120px">
+          <h2 className="text-center font-display text-3xl font-bold text-dusty-lavender md:text-4xl">
             Live Network Data
           </h2>
-          <p className="mx-auto mt-4 max-w-2xl text-center text-mist/70">
+          <p className="mx-auto mt-4 max-w-2xl text-center text-dusty-lavender/70">
             Real-time metrics from the Republic AI chain.
           </p>
         </ScrollReveal>
@@ -98,21 +101,22 @@ export function NetworkStats() {
 
         <ScrollReveal
           stagger
+          margin="-120px"
           className="mt-16 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-4"
         >
           {items.map((item) => (
             <motion.div
               key={item.label}
               variants={staggerItem}
-              className="rounded-xl border border-slate-DEFAULT/30 bg-slate-dark/50 p-6 text-center"
+              className="group rounded-xl border border-soft-violet/20 bg-deep-iris/10 p-6 text-center backdrop-blur-sm transition-all hover:border-soft-violet/30 hover:bg-deep-iris/15"
             >
-              <div className="mx-auto flex size-12 items-center justify-center rounded-full bg-slate-DEFAULT/20">
-                <item.icon className="size-6 text-slate-light" />
+              <div className="mx-auto flex size-12 items-center justify-center rounded-full bg-soft-violet/15 transition-transform group-hover:scale-110">
+                <item.icon className="size-6 text-soft-violet" />
               </div>
-              <p className="mt-4 text-sm text-mist/70">{item.label}</p>
-              <p className="mt-2 font-display text-3xl font-bold text-slate-light">
+              <p className="mt-4 text-sm text-dusty-lavender/70">{item.label}</p>
+              <p className="mt-2 font-display text-3xl font-bold text-dusty-lavender">
                 {isLoading || item.value === undefined ? (
-                  <span className="inline-block h-9 w-20 animate-pulse rounded bg-slate-DEFAULT/20" />
+                  <span className="inline-block h-9 w-20 animate-pulse rounded bg-deep-iris/20" />
                 ) : (
                   <>
                     <CountUp value={item.value} decimals={item.decimals} />

--- a/src/components/landing/scroll-reveal.tsx
+++ b/src/components/landing/scroll-reveal.tsx
@@ -4,11 +4,19 @@ import { useRef, type ReactNode } from "react";
 import { motion, useInView } from "motion/react";
 import { fadeInUp, staggerContainer } from "@/lib/animations";
 
+type UseInViewMargin = `${number}${"px" | "%"}`;
+type MarginType =
+  | UseInViewMargin
+  | `${UseInViewMargin} ${UseInViewMargin}`
+  | `${UseInViewMargin} ${UseInViewMargin} ${UseInViewMargin}`
+  | `${UseInViewMargin} ${UseInViewMargin} ${UseInViewMargin} ${UseInViewMargin}`;
+
 interface ScrollRevealProps {
   children: ReactNode;
   className?: string;
   delay?: number;
   stagger?: boolean;
+  margin?: MarginType;
 }
 
 export function ScrollReveal({
@@ -16,9 +24,10 @@ export function ScrollReveal({
   className,
   delay = 0,
   stagger = false,
+  margin = "-80px",
 }: ScrollRevealProps) {
   const ref = useRef<HTMLDivElement>(null);
-  const isInView = useInView(ref, { once: true, margin: "-80px" });
+  const isInView = useInView(ref, { once: true, margin });
 
   if (stagger) {
     return (

--- a/src/lib/animations.ts
+++ b/src/lib/animations.ts
@@ -1,11 +1,17 @@
 import type { Variants } from "motion/react";
 
 export const fadeInUp: Variants = {
-  hidden: { opacity: 0, y: 20 },
+  hidden: { opacity: 0, y: 30, scale: 0.98 },
   visible: (delay: number = 0) => ({
     opacity: 1,
     y: 0,
-    transition: { duration: 0.6, delay, ease: [0.22, 1, 0.36, 1] },
+    scale: 1,
+    transition: {
+      type: "spring",
+      stiffness: 100,
+      damping: 20,
+      delay,
+    },
   }),
 };
 
@@ -13,16 +19,21 @@ export const staggerContainer: Variants = {
   hidden: { opacity: 0 },
   visible: {
     opacity: 1,
-    transition: { staggerChildren: 0.1, delayChildren: 0.2 },
+    transition: { staggerChildren: 0.08, delayChildren: 0.2 },
   },
 };
 
 export const staggerItem: Variants = {
-  hidden: { opacity: 0, y: 20 },
+  hidden: { opacity: 0, y: 25, scale: 0.96 },
   visible: {
     opacity: 1,
     y: 0,
-    transition: { duration: 0.5, ease: [0.22, 1, 0.36, 1] },
+    scale: 1,
+    transition: {
+      type: "spring",
+      stiffness: 100,
+      damping: 20,
+    },
   },
 };
 
@@ -36,6 +47,20 @@ export const floatingParticle: Variants = {
       repeat: Infinity,
       ease: "easeInOut",
       delay: i * 0.2,
+    },
+  }),
+};
+
+export const codeLine: Variants = {
+  hidden: { opacity: 0, x: -10 },
+  visible: (i: number) => ({
+    opacity: 1,
+    x: 0,
+    transition: {
+      type: "spring",
+      stiffness: 100,
+      damping: 20,
+      delay: i * 0.1,
     },
   }),
 };

--- a/tests/unit/components/landing.test.tsx
+++ b/tests/unit/components/landing.test.tsx
@@ -11,7 +11,7 @@ vi.mock("motion/react", () => ({
         const Component = React.forwardRef(
           (props: Record<string, unknown>, ref: React.Ref<HTMLElement>) => {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { variants: _v, initial: _i, animate: _a, custom: _c, whileHover: _wh, whileTap: _wt, ...rest } = props;
+            const { variants: _v, initial: _i, animate: _a, custom: _c, whileHover: _wh, whileTap: _wt, style: _s, ...rest } = props;
             return React.createElement(prop, { ...rest, ref });
           }
         );
@@ -28,6 +28,14 @@ vi.mock("motion/react", () => ({
   }),
   useSpring: () => ({
     on: () => vi.fn(),
+  }),
+  useReducedMotion: () => false,
+  useScroll: () => ({
+    scrollYProgress: { on: vi.fn(), get: () => 0 },
+  }),
+  useTransform: () => ({
+    on: vi.fn(),
+    get: () => 0,
   }),
 }));
 


### PR DESCRIPTION
## Summary
- Replace per-section color themes (teal, slate, rose, indigo, amber) with consistent plum palette (midnight-plum, soft-violet, dusty-lavender)
- Add parallax scroll (hero), spring physics animations, line-by-line code reveal (api-teaser), gradient section separators, and global glow layer
- Add `prefers-reduced-motion` support via `useReducedMotion` hook and CSS media query — disables particles, parallax, infinite animations, and smooth scroll
- Fix ScrollReveal `margin` prop type safety (remove unsafe cast, add proper `MarginType` definition)

## Changes (11 files)
| File | Change |
|------|--------|
| `globals.css` | smooth scroll + glow utility + reduced-motion media query |
| `animations.ts` | spring physics, scale transitions, `codeLine` variant |
| `scroll-reveal.tsx` | parametric `margin` prop with proper typing |
| `hero.tsx` | `useScroll`/`useTransform` parallax, `useReducedMotion`, button hover effects |
| `features.tsx` | plum palette + semantic icon colors (teal=health, violet=primary, amber=alert) |
| `network-stats.tsx` | alternate plum bg `#1a1230`, soft-violet icons |
| `how-it-works.tsx` | plum palette, ring effects, shadow glow |
| `api-teaser.tsx` | line-by-line code reveal with `useReducedMotion` fallback |
| `cta.tsx` | plum palette (server component, no hooks) |
| `page.tsx` | global glow layer + `bg-midnight-plum` wrapper |
| `landing.test.tsx` | `useScroll`, `useTransform`, `useReducedMotion` mocks |

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 228/228 passed
- [x] `npm run build` — successful
- [x] All sections use plum palette (no teal/rose/indigo/amber backgrounds)
- [x] Reduced motion: particles, parallax, scroll indicator, code reveal disabled