### PR TITLE
refactor(branding): prism/lens logo redesign

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,11 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
   <defs>
-    <linearGradient id="fg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#4C1D95"/>
-      <stop offset="100%" stop-color="#8B5CF6"/>
+    <linearGradient id="fg" x1="6" y1="6" x2="26" y2="26" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4C1D95"/>
+      <stop offset="1" stop-color="#8B5CF6"/>
     </linearGradient>
   </defs>
-  <circle cx="16" cy="16" r="14" fill="url(#fg)"/>
-  <circle cx="16" cy="16" r="6" fill="#1C0F2B"/>
-  <circle cx="14" cy="14" r="1.5" fill="white" opacity="0.7"/>
+  <!-- Prism body -->
+  <path d="M16 4L28 11L28 21L16 28L4 21L4 11Z" fill="url(#fg)"/>
+  <!-- Facet highlight -->
+  <path d="M16 4L28 11L16 16Z" fill="white" opacity=".1"/>
+  <!-- Center point -->
+  <circle cx="16" cy="16" r="2.5" fill="#1C0F2B"/>
+  <circle cx="15.2" cy="15" r=".8" fill="white" opacity=".5"/>
 </svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,20 +1,48 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
   <defs>
-    <linearGradient id="panoptes-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#4C1D95"/>
-      <stop offset="100%" stop-color="#8B5CF6"/>
+    <linearGradient id="pg" x1="32" y1="28" x2="88" y2="86" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#4C1D95"/>
+      <stop offset="1" stop-color="#8B5CF6"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="60" cy="57" r="45" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#8B5CF6" stop-opacity=".15"/>
+      <stop offset="1" stop-color="#8B5CF6" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="ib" x1="60" y1="4" x2="60" y2="30" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#C4B5FD" stop-opacity="0"/>
+      <stop offset="1" stop-color="#C4B5FD" stop-opacity=".8"/>
+    </linearGradient>
+    <linearGradient id="ob-l" x1="46" y1="78" x2="22" y2="114" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#C4B5FD" stop-opacity=".7"/>
+      <stop offset="1" stop-color="#C4B5FD" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="ob-c" x1="60" y1="86" x2="60" y2="114" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#C4B5FD" stop-opacity=".7"/>
+      <stop offset="1" stop-color="#C4B5FD" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="ob-r" x1="74" y1="78" x2="98" y2="114" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#C4B5FD" stop-opacity=".7"/>
+      <stop offset="1" stop-color="#C4B5FD" stop-opacity="0"/>
     </linearGradient>
   </defs>
-  <!-- Outer eye shape -->
-  <path d="M60 20C30 20 10 60 10 60s20 40 50 40 50-40 50-40S90 20 60 20z" fill="url(#panoptes-grad)" opacity="0.15"/>
-  <!-- Inner eye ring -->
-  <circle cx="60" cy="60" r="28" stroke="url(#panoptes-grad)" stroke-width="3" fill="none"/>
-  <!-- Iris -->
-  <circle cx="60" cy="60" r="16" fill="url(#panoptes-grad)" opacity="0.85"/>
-  <!-- Pupil -->
-  <circle cx="60" cy="60" r="7" fill="#1C0F2B"/>
-  <!-- Light reflection -->
-  <circle cx="54" cy="54" r="3" fill="white" opacity="0.6"/>
-  <!-- P letterform integrated as highlight arc -->
-  <path d="M52 40v40M52 40h10a12 12 0 010 24H52" stroke="white" stroke-width="2.5" stroke-linecap="round" fill="none" opacity="0.9"/>
+  <!-- Ambient glow -->
+  <circle cx="60" cy="57" r="45" fill="url(#glow)"/>
+  <!-- Input beam -->
+  <line x1="60" y1="4" x2="60" y2="30" stroke="url(#ib)" stroke-width="2" stroke-linecap="round"/>
+  <!-- Prism body -->
+  <path d="M60 28L88 44L88 70L60 86L32 70L32 44Z" fill="url(#pg)"/>
+  <!-- Facet lines -->
+  <path d="M60 28L60 86" stroke="#C4B5FD" stroke-width=".5" opacity=".2"/>
+  <path d="M32 44L88 70" stroke="#C4B5FD" stroke-width=".5" opacity=".15"/>
+  <path d="M88 44L32 70" stroke="#C4B5FD" stroke-width=".5" opacity=".15"/>
+  <!-- Upper facet highlights -->
+  <path d="M60 28L88 44L60 57Z" fill="white" opacity=".08"/>
+  <path d="M60 28L32 44L60 57Z" fill="white" opacity=".04"/>
+  <!-- Center lens point -->
+  <circle cx="60" cy="57" r="6" fill="#1C0F2B"/>
+  <circle cx="58" cy="55" r="1.8" fill="white" opacity=".5"/>
+  <!-- Output beams -->
+  <line x1="46" y1="78" x2="22" y2="114" stroke="url(#ob-l)" stroke-width="2" stroke-linecap="round"/>
+  <line x1="60" y1="86" x2="60" y2="114" stroke="url(#ob-c)" stroke-width="2" stroke-linecap="round"/>
+  <line x1="74" y1="78" x2="98" y2="114" stroke="url(#ob-r)" stroke-width="2" stroke-linecap="round"/>
 </svg>

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -21,19 +21,29 @@ export default function OGImage() {
           fontFamily: "sans-serif",
         }}
       >
-        {/* Eye icon */}
+        {/* Prism icon */}
         <svg
-          width="80"
-          height="80"
-          viewBox="0 0 24 24"
+          width="100"
+          height="100"
+          viewBox="0 0 120 120"
           fill="none"
-          stroke="#8B5CF6"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
         >
-          <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
-          <circle cx="12" cy="12" r="3" />
+          <circle cx="60" cy="57" r="45" fill="rgba(139,92,246,0.15)" />
+          <line x1="60" y1="4" x2="60" y2="30" stroke="rgba(196,181,253,0.8)" strokeWidth="2" strokeLinecap="round" />
+          <path d="M60 28L88 44L88 70L60 86L32 70L32 44Z" fill="url(#og-pg)" />
+          <path d="M60 28L88 44L60 57Z" fill="white" opacity="0.08" />
+          <path d="M60 28L32 44L60 57Z" fill="white" opacity="0.04" />
+          <circle cx="60" cy="57" r="6" fill="#1C0F2B" />
+          <circle cx="58" cy="55" r="1.8" fill="white" opacity="0.5" />
+          <line x1="46" y1="78" x2="22" y2="114" stroke="rgba(196,181,253,0.7)" strokeWidth="2" strokeLinecap="round" />
+          <line x1="60" y1="86" x2="60" y2="114" stroke="rgba(196,181,253,0.7)" strokeWidth="2" strokeLinecap="round" />
+          <line x1="74" y1="78" x2="98" y2="114" stroke="rgba(196,181,253,0.7)" strokeWidth="2" strokeLinecap="round" />
+          <defs>
+            <linearGradient id="og-pg" x1="32" y1="28" x2="88" y2="86" gradientUnits="userSpaceOnUse">
+              <stop stopColor="#4C1D95" />
+              <stop offset="1" stopColor="#8B5CF6" />
+            </linearGradient>
+          </defs>
         </svg>
 
         <div

--- a/src/components/dashboard/sidebar.tsx
+++ b/src/components/dashboard/sidebar.tsx
@@ -11,9 +11,9 @@ import {
   AlertTriangle,
   Menu,
   X,
-  Eye,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { PrismIcon } from "@/components/icons/prism-icon";
 
 const navItems = [
   { href: "/dashboard", label: "Overview", icon: LayoutDashboard },
@@ -36,7 +36,7 @@ export function Sidebar() {
     <>
       <div className="flex items-center gap-2.5 px-6 py-5">
         <div className="flex size-8 items-center justify-center rounded-lg bg-soft-violet/20">
-          <Eye className="size-4 text-soft-violet" />
+          <PrismIcon className="size-4 text-soft-violet" />
         </div>
         <h2 className="font-display text-lg font-bold text-soft-violet">
           Panoptes
@@ -92,7 +92,7 @@ export function Sidebar() {
           <Menu className="size-5" />
         </button>
         <div className="flex items-center gap-2">
-          <Eye className="size-4 text-soft-violet" />
+          <PrismIcon className="size-4 text-soft-violet" />
           <span className="font-display text-sm font-bold text-soft-violet">
             Panoptes
           </span>

--- a/src/components/icons/prism-icon.tsx
+++ b/src/components/icons/prism-icon.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+
+interface PrismIconProps {
+  className?: string;
+}
+
+export function PrismIcon({ className }: PrismIconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={cn("size-4", className)}
+    >
+      <defs>
+        <linearGradient id="pi-g" x1="4" y1="3" x2="20" y2="21" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#4C1D95" />
+          <stop offset="1" stopColor="#8B5CF6" />
+        </linearGradient>
+      </defs>
+      <path d="M12 3L21 8L21 16L12 21L3 16L3 8Z" fill="url(#pi-g)" />
+      <path d="M12 3L21 8L12 12Z" fill="white" opacity=".1" />
+      <circle cx="12" cy="12" r="1.8" fill="#1C0F2B" />
+      <circle cx="11.5" cy="11.3" r=".6" fill="white" opacity=".5" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- Replace eye-based logo with unified prism/lens concept across all assets
- New design: hexagonal gem with input beam, faceted surface, dark center lens point, and 3 output beams (representing Index → Analyze → Route pipeline)
- No text in logo — pure geometric design

## Changed Assets
| Asset | Before | After |
|-------|--------|-------|
| `logo.svg` (120px) | Eye + P letter | Full prism + beams + ambient glow |
| `favicon.svg` (32px) | Circle eye | Minimal hexagonal prism |
| `opengraph-image.tsx` | Lucide Eye SVG | Inline prism SVG |
| `sidebar.tsx` | Lucide `Eye` import | Custom `PrismIcon` component |
| `prism-icon.tsx` | (new) | Reusable 24px prism icon |

## Design Consistency
All 4 usage points now share the same visual language: hexagonal prism body, deep-iris→soft-violet gradient, midnight-plum center point, white facet highlight.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 228/228 passed
- [x] `npm run build` — successful