### PR TITLE
fix(seo): resolve robots/sitemap conflict and breadcrumb gap

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,0 @@
-User-agent: *
-Allow: /
-Disallow: /api/
-Disallow: /dashboard/
-
-Sitemap: https://panoptes.republicai.io/sitemap.xml

--- a/src/app/dashboard/anomalies/page.tsx
+++ b/src/app/dashboard/anomalies/page.tsx
@@ -69,6 +69,7 @@ export default function AnomaliesPage() {
       <PageHeader
         title="Anomalies"
         description="Network anomaly detection and alerts"
+        breadcrumbs={[{ label: "Anomalies" }]}
       />
 
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center">

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL =
+  process.env.NEXT_PUBLIC_APP_URL || "https://panoptes.republicai.io";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/api/", "/dashboard/"],
+    },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -11,35 +11,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "weekly",
       priority: 1,
     },
-    {
-      url: `${BASE_URL}/dashboard`,
-      lastModified: new Date(),
-      changeFrequency: "always",
-      priority: 0.9,
-    },
-    {
-      url: `${BASE_URL}/dashboard/validators`,
-      lastModified: new Date(),
-      changeFrequency: "always",
-      priority: 0.8,
-    },
-    {
-      url: `${BASE_URL}/dashboard/endpoints`,
-      lastModified: new Date(),
-      changeFrequency: "always",
-      priority: 0.8,
-    },
-    {
-      url: `${BASE_URL}/dashboard/anomalies`,
-      lastModified: new Date(),
-      changeFrequency: "always",
-      priority: 0.7,
-    },
-    {
-      url: `${BASE_URL}/dashboard/network`,
-      lastModified: new Date(),
-      changeFrequency: "always",
-      priority: 0.7,
-    },
   ];
 }


### PR DESCRIPTION
## Summary

- **SEO consistency**: Dashboard URLs removed from sitemap.xml (were conflicting with robots.txt disallow rules)
- **Dynamic robots.ts**: Replaced static `public/robots.txt` with `src/app/robots.ts` — sitemap URL now derived from `NEXT_PUBLIC_APP_URL` instead of hardcoded domain
- **Breadcrumb fix**: Added missing breadcrumb to anomalies page normal render (was only present in error state)

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm test` — 228/228 passed
- `npm run build` — `/robots.txt` and `/sitemap.xml` routes generated correctly

## Test plan

- [ ] Verify `/robots.txt` renders with correct disallow rules and dynamic sitemap URL
- [ ] Verify `/sitemap.xml` contains only public (non-dashboard) URLs
- [ ] Verify anomalies page shows breadcrumb in normal (non-error) state