### PR TITLE
fix(ui): resolve prism icon not rendering in sidebar

### DIFF
--- a/src/components/icons/prism-icon.tsx
+++ b/src/components/icons/prism-icon.tsx
@@ -12,14 +12,9 @@ export function PrismIcon({ className }: PrismIconProps) {
       xmlns="http://www.w3.org/2000/svg"
       className={cn("size-4", className)}
     >
-      <defs>
-        <linearGradient id="pi-g" x1="4" y1="3" x2="20" y2="21" gradientUnits="userSpaceOnUse">
-          <stop stopColor="#4C1D95" />
-          <stop offset="1" stopColor="#8B5CF6" />
-        </linearGradient>
-      </defs>
-      <path d="M12 3L21 8L21 16L12 21L3 16L3 8Z" fill="url(#pi-g)" />
-      <path d="M12 3L21 8L12 12Z" fill="white" opacity=".1" />
+      <path d="M12 3L21 8L21 16L12 21L3 16L3 8Z" fill="currentColor" />
+      <path d="M12 3L21 8L12 12Z" fill="white" opacity=".15" />
+      <path d="M12 12L3 8L3 16Z" fill="black" opacity=".1" />
       <circle cx="12" cy="12" r="1.8" fill="#1C0F2B" />
       <circle cx="11.5" cy="11.3" r=".6" fill="white" opacity=".5" />
     </svg>


### PR DESCRIPTION
## Summary

- Prism icon was not visible in dashboard sidebar due to SVG `linearGradient` id collision when multiple instances render on the same page
- Replaced `fill="url(#pi-g)"` with `fill="currentColor"` so the icon inherits color from Tailwind `text-soft-violet` class
- Added subtle facet shading for depth

## Test plan

- [ ] Verify prism icon is visible in desktop sidebar (next to "Panoptes" title)
- [ ] Verify prism icon is visible in mobile header bar
- [ ] 228/228 tests passing