### PR TITLE
feat(auth): add workspace authentication with admin token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,12 @@ CRON_SECRET="change-me-to-a-strong-random-string"
 # Set to "true" in GitHub Actions to enable scheduled cron jobs
 CRONS_ENABLED="false"
 
+# ── Workspace Auth ────────────────────────────────────────────
+# Admin token for the default workspace (used by seed + API auth)
+# Generate with: openssl rand -hex 32
+# Prefix with ws_ for clarity: ws_<random-hex>
+PANOPTES_ADMIN_TOKEN="ws_change-me-to-a-strong-random-string"
+
 # ── Application ────────────────────────────────────────────────
 # Public URL (used for CORS, sitemap, OG images)
 NEXT_PUBLIC_APP_URL="http://localhost:3000"

--- a/prisma/migrations/20260311150000_add_workspace_model/migration.sql
+++ b/prisma/migrations/20260311150000_add_workspace_model/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE "Workspace" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "adminTokenHash" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Workspace_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Workspace_slug_key" ON "Workspace"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Workspace_adminTokenHash_key" ON "Workspace"("adminTokenHash");
+
+-- CreateIndex
+CREATE INDEX "Workspace_slug_idx" ON "Workspace"("slug");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -134,3 +134,15 @@ model Anomaly {
   @@index([detectedAt])
   @@index([resolved])
 }
+
+model Workspace {
+  id             String   @id @default(cuid())
+  name           String
+  slug           String   @unique
+  adminTokenHash String   @unique
+  isActive       Boolean  @default(true)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  @@index([slug])
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,6 +3,7 @@ import "dotenv/config";
 import { neonConfig } from "@neondatabase/serverless";
 import { PrismaNeon } from "@prisma/adapter-neon";
 import { PrismaClient } from "../src/generated/prisma/client.js";
+import { hashToken } from "../src/lib/workspace-auth.js";
 import ws from "ws";
 
 neonConfig.webSocketConstructor = ws;
@@ -50,6 +51,32 @@ async function main() {
       },
     });
     console.log(`  + ${ep.url} (${ep.type})`);
+  }
+
+  // Seed default workspace
+  const adminToken = process.env.PANOPTES_ADMIN_TOKEN;
+  if (adminToken) {
+    const tokenHash = hashToken(adminToken);
+    await prisma.workspace.upsert({
+      where: { slug: "default" },
+      create: {
+        name: "Default Workspace",
+        slug: "default",
+        adminTokenHash: tokenHash,
+      },
+      update: {
+        adminTokenHash: tokenHash,
+      },
+    });
+    console.log("  + Default workspace (slug: default)");
+  } else if (process.env.NODE_ENV === "production") {
+    throw new Error(
+      "PANOPTES_ADMIN_TOKEN is required in production. Generate with: openssl rand -hex 32",
+    );
+  } else {
+    console.warn(
+      "  ⚠ PANOPTES_ADMIN_TOKEN not set, skipping workspace seed (non-production)",
+    );
   }
 
   console.log("[seed] Done.");

--- a/src/lib/workspace-auth.ts
+++ b/src/lib/workspace-auth.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createHash, timingSafeEqual } from "crypto";
+import { prisma } from "@/lib/db";
+
+export interface WorkspaceContext {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+/**
+ * Hash a raw workspace token using SHA-256.
+ * Used both at seed time (to store the hash) and at request time (to look up).
+ */
+export function hashToken(rawToken: string): string {
+  return createHash("sha256").update(rawToken).digest("hex");
+}
+
+/**
+ * Extract Bearer token from Authorization header.
+ * Returns null if header is missing or malformed.
+ */
+export function extractBearerToken(request: NextRequest): string | null {
+  const header = request.headers.get("authorization");
+  if (!header?.startsWith("Bearer ")) return null;
+  const token = header.slice(7).trim();
+  return token.length > 0 ? token : null;
+}
+
+/**
+ * Authenticate a request using workspace Bearer token.
+ *
+ * Flow:
+ * 1. Extract Bearer token from Authorization header
+ * 2. SHA-256 hash the token
+ * 3. Look up workspace by adminTokenHash
+ * 4. Return workspace context if found and active
+ *
+ * Returns null if authentication fails (no token, invalid, inactive).
+ */
+export async function authenticateWorkspace(
+  request: NextRequest,
+): Promise<WorkspaceContext | null> {
+  const rawToken = extractBearerToken(request);
+  if (!rawToken) return null;
+
+  const tokenHash = hashToken(rawToken);
+
+  const workspace = await prisma.workspace.findFirst({
+    where: { adminTokenHash: tokenHash, isActive: true },
+    select: { id: true, name: true, slug: true, adminTokenHash: true },
+  });
+
+  if (!workspace) return null;
+
+  // Timing-safe comparison to prevent timing attacks
+  const storedHash = Buffer.from(workspace.adminTokenHash, "utf-8");
+  const providedHash = Buffer.from(tokenHash, "utf-8");
+  if (
+    storedHash.length !== providedHash.length ||
+    !timingSafeEqual(storedHash, providedHash)
+  ) {
+    return null;
+  }
+
+  return { id: workspace.id, name: workspace.name, slug: workspace.slug };
+}
+
+/**
+ * Require workspace authentication for a route handler.
+ * Returns 401 if not authenticated.
+ * Use in write endpoints (POST/PATCH/DELETE for webhooks, SLOs, policies).
+ */
+export function requireWorkspace(
+  request: NextRequest,
+): Promise<
+  | { workspace: WorkspaceContext; error?: never }
+  | { workspace?: never; error: NextResponse }
+> {
+  return authenticateWorkspace(request).then((workspace) => {
+    if (!workspace) {
+      return {
+        error: NextResponse.json(
+          { error: "Unauthorized — valid workspace token required" },
+          { status: 401 },
+        ),
+      };
+    }
+    return { workspace };
+  });
+}

--- a/tests/unit/lib/workspace-auth.test.ts
+++ b/tests/unit/lib/workspace-auth.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    workspace: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/db";
+import {
+  hashToken,
+  extractBearerToken,
+  authenticateWorkspace,
+  requireWorkspace,
+} from "@/lib/workspace-auth";
+
+const TEST_TOKEN = "ws_test-token-abc123";
+
+describe("hashToken", () => {
+  it("returns consistent SHA-256 hex digest", () => {
+    const hash1 = hashToken("test-token");
+    const hash2 = hashToken("test-token");
+    expect(hash1).toBe(hash2);
+    expect(hash1).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("returns different hash for different tokens", () => {
+    const hash1 = hashToken("token-a");
+    const hash2 = hashToken("token-b");
+    expect(hash1).not.toBe(hash2);
+  });
+
+  it("returns 64-char hex string", () => {
+    const hash = hashToken("any-token");
+    expect(hash).toHaveLength(64);
+  });
+});
+
+describe("extractBearerToken", () => {
+  it("extracts token from valid Bearer header", () => {
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: "Bearer ws_my-token" },
+    });
+    expect(extractBearerToken(req)).toBe("ws_my-token");
+  });
+
+  it("returns null when no Authorization header", () => {
+    const req = new NextRequest("http://localhost/api/test");
+    expect(extractBearerToken(req)).toBeNull();
+  });
+
+  it("returns null for non-Bearer auth", () => {
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: "Basic abc123" },
+    });
+    expect(extractBearerToken(req)).toBeNull();
+  });
+
+  it("returns null for empty Bearer value", () => {
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: "Bearer " },
+    });
+    expect(extractBearerToken(req)).toBeNull();
+  });
+
+  it("trims whitespace from token", () => {
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: "Bearer  ws_my-token  " },
+    });
+    expect(extractBearerToken(req)).toBe("ws_my-token");
+  });
+});
+
+describe("authenticateWorkspace", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns workspace context for valid token", async () => {
+    const tokenHash = hashToken(TEST_TOKEN);
+    vi.mocked(prisma.workspace.findFirst).mockResolvedValue({
+      id: "ws-1",
+      name: "Test Workspace",
+      slug: "test",
+      adminTokenHash: tokenHash,
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: `Bearer ${TEST_TOKEN}` },
+    });
+
+    const result = await authenticateWorkspace(req);
+    expect(result).toEqual({
+      id: "ws-1",
+      name: "Test Workspace",
+      slug: "test",
+    });
+  });
+
+  it("returns null when no Authorization header", async () => {
+    const req = new NextRequest("http://localhost/api/test");
+    const result = await authenticateWorkspace(req);
+    expect(result).toBeNull();
+    expect(prisma.workspace.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns null for invalid token", async () => {
+    vi.mocked(prisma.workspace.findFirst).mockResolvedValue(null);
+
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: "Bearer ws_invalid-token" },
+    });
+
+    const result = await authenticateWorkspace(req);
+    expect(result).toBeNull();
+  });
+
+  it("returns null for inactive workspace", async () => {
+    vi.mocked(prisma.workspace.findFirst).mockResolvedValue(null);
+
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: `Bearer ${TEST_TOKEN}` },
+    });
+
+    const result = await authenticateWorkspace(req);
+    expect(result).toBeNull();
+  });
+
+  it("queries with hashed token and isActive filter", async () => {
+    vi.mocked(prisma.workspace.findFirst).mockResolvedValue(null);
+
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { Authorization: `Bearer ${TEST_TOKEN}` },
+    });
+
+    await authenticateWorkspace(req);
+
+    expect(prisma.workspace.findFirst).toHaveBeenCalledWith({
+      where: {
+        adminTokenHash: hashToken(TEST_TOKEN),
+        isActive: true,
+      },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        adminTokenHash: true,
+      },
+    });
+  });
+});
+
+describe("requireWorkspace", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns workspace when authenticated", async () => {
+    const tokenHash = hashToken(TEST_TOKEN);
+    vi.mocked(prisma.workspace.findFirst).mockResolvedValue({
+      id: "ws-1",
+      name: "Test Workspace",
+      slug: "test",
+      adminTokenHash: tokenHash,
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const req = new NextRequest("http://localhost/api/webhooks", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${TEST_TOKEN}` },
+    });
+
+    const result = await requireWorkspace(req);
+    expect(result.workspace).toBeDefined();
+    expect(result.error).toBeUndefined();
+    expect(result.workspace!.id).toBe("ws-1");
+  });
+
+  it("returns 401 error when not authenticated", async () => {
+    const req = new NextRequest("http://localhost/api/webhooks", {
+      method: "POST",
+    });
+
+    const result = await requireWorkspace(req);
+    expect(result.workspace).toBeUndefined();
+    expect(result.error).toBeDefined();
+    expect(result.error!.status).toBe(401);
+
+    const body = await result.error!.json();
+    expect(body.error).toContain("Unauthorized");
+  });
+
+  it("returns 401 for invalid token", async () => {
+    vi.mocked(prisma.workspace.findFirst).mockResolvedValue(null);
+
+    const req = new NextRequest("http://localhost/api/webhooks", {
+      method: "POST",
+      headers: { Authorization: "Bearer ws_wrong-token" },
+    });
+
+    const result = await requireWorkspace(req);
+    expect(result.workspace).toBeUndefined();
+    expect(result.error).toBeDefined();
+    expect(result.error!.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 7 (v1.1.0) — Workspace Auth altyapısı. Multi-tenant workspace modeli ve admin token bazlı kimlik doğrulama sistemi.

- **Workspace modeli** eklendi (`slug` + `adminTokenHash` unique index'leri ile)
- **Prisma migration** oluşturuldu (`20260311150000_add_workspace_model`)
- **workspace-auth utility** — `hashToken` (SHA-256), `extractBearerToken`, `authenticateWorkspace` (timing-safe comparison), `requireWorkspace` (401 wrapper)
- **Seed script** güncellendi — `PANOPTES_ADMIN_TOKEN` ile default workspace bootstrap, production'da token yoksa fail-fast
- **DRY refactor** — seed, shared `hashToken` helper kullanıyor (inline crypto tekrarı kaldırıldı)
- `.env.example` güncellendi

## Test

- 16 yeni unit test (hashToken, extractBearerToken, authenticateWorkspace, requireWorkspace)
- **244/244 test passed**
- `tsc --noEmit` temiz
- `npm run lint` temiz
- `npm run build` başarılı

## Test plan

- [x] `npm run lint` — hata yok
- [x] `npx tsc --noEmit` — hata yok
- [x] `npm test` — 244/244 passed
- [x] `npm run build` — başarılı
- [ ] Deploy sonrası `prisma migrate deploy` ile Workspace tablosu oluşturulacak
- [ ] `PANOPTES_ADMIN_TOKEN` env var Vercel'e eklenecek
- [ ] Seed çalıştırılıp default workspace doğrulanacak