### PR TITLE
fix(ops): log response body and HTTP status in cron workflows

### DIFF
--- a/.github/workflows/cron-cleanup.yml
+++ b/.github/workflows/cron-cleanup.yml
@@ -17,6 +17,13 @@ jobs:
     steps:
       - name: Trigger data cleanup
         run: |
-          curl -sf -X POST "${{ secrets.APP_URL }}/api/cron/cleanup" \
+          HTTP_CODE=$(curl -s -o /tmp/response.json -w "%{http_code}" \
+            -X POST "${{ secrets.APP_URL }}/api/cron/cleanup" \
             -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
-            -H "Content-Type: application/json"
+            -H "Content-Type: application/json")
+          echo "HTTP Status: $HTTP_CODE"
+          cat /tmp/response.json || true
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Cron cleanup failed with HTTP $HTTP_CODE"
+            exit 1
+          fi

--- a/.github/workflows/cron-health.yml
+++ b/.github/workflows/cron-health.yml
@@ -17,6 +17,13 @@ jobs:
     steps:
       - name: Trigger health check
         run: |
-          curl -sf -X POST "${{ secrets.APP_URL }}/api/cron/health" \
+          HTTP_CODE=$(curl -s -o /tmp/response.json -w "%{http_code}" \
+            -X POST "${{ secrets.APP_URL }}/api/cron/health" \
             -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
-            -H "Content-Type: application/json"
+            -H "Content-Type: application/json")
+          echo "HTTP Status: $HTTP_CODE"
+          cat /tmp/response.json || true
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Cron health check failed with HTTP $HTTP_CODE"
+            exit 1
+          fi

--- a/.github/workflows/cron-stats.yml
+++ b/.github/workflows/cron-stats.yml
@@ -17,6 +17,13 @@ jobs:
     steps:
       - name: Trigger stats aggregation
         run: |
-          curl -sf -X POST "${{ secrets.APP_URL }}/api/cron/stats" \
+          HTTP_CODE=$(curl -s -o /tmp/response.json -w "%{http_code}" \
+            -X POST "${{ secrets.APP_URL }}/api/cron/stats" \
             -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
-            -H "Content-Type: application/json"
+            -H "Content-Type: application/json")
+          echo "HTTP Status: $HTTP_CODE"
+          cat /tmp/response.json || true
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Cron stats failed with HTTP $HTTP_CODE"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Cron workflow'lardaki `curl -sf` pattern'ını response body + HTTP status loglayan pattern ile değiştir
- Artık fail durumunda response body ve HTTP kodu Actions log'larında görünecek
- `::error::` annotation ile GitHub Actions UI'da hata vurgulanacak

**Etkilenen workflow'lar:** `cron-stats.yml`, `cron-health.yml`, `cron-cleanup.yml`

**Motivasyon:** Mevcut `curl -sf` sadece exit code 22 bırakıyor, gerçek hata nedeni (502, timeout, auth fail vs.) teşhis edilemiyor.

Closes #16

## Test plan

- [x] YAML syntax valid
- [ ] Workflow dispatch ile manual trigger sonrası log'da HTTP status + body görünmeli