### PR TITLE
feat(webhooks): webhook CRUD API with encryption and SSRF protection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ CRONS_ENABLED="false"
 # Prefix with ws_ for clarity: ws_<random-hex>
 PANOPTES_ADMIN_TOKEN="ws_change-me-to-a-strong-random-string"
 
+# ── Webhook Security ─────────────────────────────────────────
+# AES-256-GCM encryption key for webhook signing secrets
+# Generate with: openssl rand -hex 32
+WEBHOOK_ENCRYPTION_KEY="change-me-to-a-64-char-hex-string"
+
 # ── Application ────────────────────────────────────────────────
 # Public URL (used for CORS, sitemap, OG images)
 NEXT_PUBLIC_APP_URL="http://localhost:3000"

--- a/prisma/migrations/20260312150000_add_webhook_models/migration.sql
+++ b/prisma/migrations/20260312150000_add_webhook_models/migration.sql
@@ -1,0 +1,91 @@
+-- CreateTable
+CREATE TABLE "Webhook" (
+    "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "secretEncrypted" TEXT NOT NULL,
+    "events" TEXT[],
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Webhook_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "WebhookDelivery" (
+    "id" TEXT NOT NULL,
+    "webhookId" TEXT NOT NULL,
+    "outboxEventId" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "payload" TEXT NOT NULL,
+    "statusCode" INTEGER,
+    "responseBody" TEXT,
+    "success" BOOLEAN NOT NULL DEFAULT false,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "maxAttempts" INTEGER NOT NULL DEFAULT 5,
+    "nextRetryAt" TIMESTAMP(3),
+    "deliveredAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WebhookDelivery_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OutboxEvent" (
+    "id" TEXT NOT NULL,
+    "seq" SERIAL NOT NULL,
+    "channel" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "visibility" TEXT NOT NULL DEFAULT 'public',
+    "workspaceId" TEXT,
+    "payload" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OutboxEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "WebhookCursor" (
+    "id" TEXT NOT NULL DEFAULT 'singleton',
+    "lastSeq" INTEGER NOT NULL DEFAULT 0,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "WebhookCursor_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Webhook_workspaceId_idx" ON "Webhook"("workspaceId");
+
+-- CreateIndex
+CREATE INDEX "Webhook_isActive_idx" ON "Webhook"("isActive");
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_webhookId_createdAt_idx" ON "WebhookDelivery"("webhookId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "WebhookDelivery_success_nextRetryAt_idx" ON "WebhookDelivery"("success", "nextRetryAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WebhookDelivery_webhookId_outboxEventId_key" ON "WebhookDelivery"("webhookId", "outboxEventId");
+
+-- CreateIndex
+CREATE INDEX "OutboxEvent_seq_idx" ON "OutboxEvent"("seq");
+
+-- CreateIndex
+CREATE INDEX "OutboxEvent_channel_seq_idx" ON "OutboxEvent"("channel", "seq");
+
+-- CreateIndex
+CREATE INDEX "OutboxEvent_workspaceId_seq_idx" ON "OutboxEvent"("workspaceId", "seq");
+
+-- AddForeignKey
+ALTER TABLE "Webhook" ADD CONSTRAINT "Webhook_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "WebhookDelivery" ADD CONSTRAINT "WebhookDelivery_webhookId_fkey" FOREIGN KEY ("webhookId") REFERENCES "Webhook"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Seed WebhookCursor singleton
+INSERT INTO "WebhookCursor" ("id", "lastSeq", "updatedAt")
+VALUES ('singleton', 0, NOW())
+ON CONFLICT ("id") DO NOTHING;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -136,13 +136,73 @@ model Anomaly {
 }
 
 model Workspace {
-  id             String   @id @default(cuid())
+  id             String    @id @default(cuid())
   name           String
-  slug           String   @unique
-  adminTokenHash String   @unique
-  isActive       Boolean  @default(true)
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  slug           String    @unique
+  adminTokenHash String    @unique
+  isActive       Boolean   @default(true)
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+  webhooks       Webhook[]
 
   @@index([slug])
+}
+
+model Webhook {
+  id              String            @id @default(cuid())
+  workspaceId     String
+  workspace       Workspace         @relation(fields: [workspaceId], references: [id])
+  name            String
+  url             String
+  secretEncrypted String
+  events          String[]
+  isActive        Boolean           @default(true)
+  createdAt       DateTime          @default(now())
+  updatedAt       DateTime          @updatedAt
+  deliveries      WebhookDelivery[]
+
+  @@index([workspaceId])
+  @@index([isActive])
+}
+
+model WebhookDelivery {
+  id            String    @id @default(cuid())
+  webhookId     String
+  webhook       Webhook   @relation(fields: [webhookId], references: [id], onDelete: Cascade)
+  outboxEventId String
+  eventType     String
+  payload       String
+  statusCode    Int?
+  responseBody  String?
+  success       Boolean   @default(false)
+  attempts      Int       @default(0)
+  maxAttempts   Int       @default(5)
+  nextRetryAt   DateTime?
+  deliveredAt   DateTime?
+  createdAt     DateTime  @default(now())
+
+  @@unique([webhookId, outboxEventId])
+  @@index([webhookId, createdAt])
+  @@index([success, nextRetryAt])
+}
+
+model OutboxEvent {
+  id          String   @id @default(cuid())
+  seq         Int      @default(autoincrement())
+  channel     String
+  type        String
+  visibility  String   @default("public")
+  workspaceId String?
+  payload     String
+  createdAt   DateTime @default(now())
+
+  @@index([seq])
+  @@index([channel, seq])
+  @@index([workspaceId, seq])
+}
+
+model WebhookCursor {
+  id        String   @id @default("singleton")
+  lastSeq   Int      @default(0)
+  updatedAt DateTime @updatedAt
 }

--- a/src/app/api/webhooks/[id]/deliveries/route.ts
+++ b/src/app/api/webhooks/[id]/deliveries/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { withRateLimit } from "@/lib/api-helpers";
+import { requireWorkspace } from "@/lib/workspace-auth";
+import { parseIntParam } from "@/lib/validation";
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const auth = await requireWorkspace(request);
+  if (auth.error) return auth.error;
+
+  const { id } = await context.params;
+
+  const webhook = await prisma.webhook.findFirst({
+    where: { id, workspaceId: auth.workspace.id },
+    select: { id: true },
+  });
+  if (!webhook) {
+    return NextResponse.json(
+      { error: "Webhook not found" },
+      { status: 404, headers: rl.headers },
+    );
+  }
+
+  const searchParams = request.nextUrl.searchParams;
+  const limit = parseIntParam(searchParams.get("limit"), 20, 1, 100);
+  const offset = parseIntParam(searchParams.get("offset"), 0, 0, 10000);
+
+  const [deliveries, total] = await Promise.all([
+    prisma.webhookDelivery.findMany({
+      where: { webhookId: id },
+      orderBy: { createdAt: "desc" },
+      take: limit,
+      skip: offset,
+      select: {
+        id: true,
+        eventType: true,
+        statusCode: true,
+        success: true,
+        attempts: true,
+        deliveredAt: true,
+        createdAt: true,
+      },
+    }),
+    prisma.webhookDelivery.count({ where: { webhookId: id } }),
+  ]);
+
+  return NextResponse.json(
+    { deliveries, total, limit, offset },
+    { headers: rl.headers },
+  );
+}

--- a/src/app/api/webhooks/[id]/route.ts
+++ b/src/app/api/webhooks/[id]/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { withRateLimit } from "@/lib/api-helpers";
+import { requireWorkspace } from "@/lib/workspace-auth";
+import { validateWebhookUpdate } from "@/lib/webhook-validation";
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const auth = await requireWorkspace(request);
+  if (auth.error) return auth.error;
+
+  const { id } = await context.params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400, headers: rl.headers },
+    );
+  }
+
+  const validated = validateWebhookUpdate(body);
+  if ("error" in validated) {
+    return NextResponse.json(
+      { error: validated.error },
+      { status: 400, headers: rl.headers },
+    );
+  }
+
+  const existing = await prisma.webhook.findFirst({
+    where: { id, workspaceId: auth.workspace.id },
+  });
+  if (!existing) {
+    return NextResponse.json(
+      { error: "Webhook not found" },
+      { status: 404, headers: rl.headers },
+    );
+  }
+
+  const updated = await prisma.webhook.update({
+    where: { id },
+    data: validated,
+    select: {
+      id: true,
+      name: true,
+      url: true,
+      events: true,
+      isActive: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  return NextResponse.json(updated, { headers: rl.headers });
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const auth = await requireWorkspace(request);
+  if (auth.error) return auth.error;
+
+  const { id } = await context.params;
+
+  const existing = await prisma.webhook.findFirst({
+    where: { id, workspaceId: auth.workspace.id },
+  });
+  if (!existing) {
+    return NextResponse.json(
+      { error: "Webhook not found" },
+      { status: 404, headers: rl.headers },
+    );
+  }
+
+  await prisma.webhook.delete({ where: { id } });
+
+  return new NextResponse(null, { status: 204, headers: rl.headers });
+}

--- a/src/app/api/webhooks/[id]/test/route.ts
+++ b/src/app/api/webhooks/[id]/test/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { withRateLimit } from "@/lib/api-helpers";
+import { requireWorkspace } from "@/lib/workspace-auth";
+import { decryptSecret, signPayload } from "@/lib/webhook-crypto";
+import { assertUrlNotPrivate } from "@/lib/webhook-validation";
+
+interface RouteContext {
+  params: Promise<{ id: string }>;
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const auth = await requireWorkspace(request);
+  if (auth.error) return auth.error;
+
+  const { id } = await context.params;
+
+  const webhook = await prisma.webhook.findFirst({
+    where: { id, workspaceId: auth.workspace.id },
+  });
+  if (!webhook) {
+    return NextResponse.json(
+      { error: "Webhook not found" },
+      { status: 404, headers: rl.headers },
+    );
+  }
+
+  const plainSecret = decryptSecret(webhook.secretEncrypted);
+  const testPayload = JSON.stringify({
+    type: "webhook.test",
+    timestamp: new Date().toISOString(),
+    workspace: { id: auth.workspace.id, name: auth.workspace.name },
+  });
+
+  const signature = signPayload(plainSecret, testPayload);
+
+  // DNS resolution check — blocks SSRF via DNS rebinding / private IP resolution
+  try {
+    await assertUrlNotPrivate(webhook.url);
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "URL resolves to a blocked private/internal address" },
+      { status: 400, headers: rl.headers },
+    );
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  const startTime = Date.now();
+  try {
+    const response = await fetch(webhook.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Signature": signature,
+        "X-Webhook-Event": "webhook.test",
+      },
+      body: testPayload,
+      signal: controller.signal,
+      redirect: "manual",
+    });
+
+    const responseTime = Date.now() - startTime;
+
+    return NextResponse.json(
+      {
+        success: response.ok,
+        statusCode: response.status,
+        responseTime,
+      },
+      { headers: rl.headers },
+    );
+  } catch (err) {
+    const responseTime = Date.now() - startTime;
+    const message =
+      err instanceof Error ? err.message : "Unknown error";
+
+    return NextResponse.json(
+      {
+        success: false,
+        statusCode: null,
+        responseTime,
+        error: message,
+      },
+      { headers: rl.headers },
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { withRateLimit } from "@/lib/api-helpers";
+import { requireWorkspace } from "@/lib/workspace-auth";
+import { validateWebhookCreate } from "@/lib/webhook-validation";
+import { encryptSecret, generateWebhookSecret } from "@/lib/webhook-crypto";
+import { WEBHOOK_DEFAULTS } from "@/lib/constants";
+
+export async function GET(request: NextRequest) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const auth = await requireWorkspace(request);
+  if (auth.error) return auth.error;
+
+  const webhooks = await prisma.webhook.findMany({
+    where: { workspaceId: auth.workspace.id },
+    select: {
+      id: true,
+      name: true,
+      url: true,
+      events: true,
+      isActive: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json({ webhooks }, { headers: rl.headers });
+}
+
+export async function POST(request: NextRequest) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const auth = await requireWorkspace(request);
+  if (auth.error) return auth.error;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400, headers: rl.headers },
+    );
+  }
+
+  const validated = validateWebhookCreate(body);
+  if ("error" in validated) {
+    return NextResponse.json(
+      { error: validated.error },
+      { status: 400, headers: rl.headers },
+    );
+  }
+
+  const plainSecret = generateWebhookSecret();
+  const secretEncrypted = encryptSecret(plainSecret);
+
+  const webhook = await prisma.$transaction(async (tx) => {
+    // Lock workspace row to serialize concurrent webhook creation
+    await tx.$queryRaw`SELECT id FROM "Workspace" WHERE id = ${auth.workspace.id} FOR UPDATE`;
+    const count = await tx.webhook.count({
+      where: { workspaceId: auth.workspace.id },
+    });
+    if (count >= WEBHOOK_DEFAULTS.MAX_PER_WORKSPACE) {
+      return null;
+    }
+    return tx.webhook.create({
+      data: {
+        workspaceId: auth.workspace.id,
+        name: validated.name,
+        url: validated.url,
+        events: validated.events,
+        secretEncrypted,
+      },
+      select: {
+        id: true,
+        name: true,
+        url: true,
+        events: true,
+        isActive: true,
+        createdAt: true,
+      },
+    });
+  });
+
+  if (!webhook) {
+    return NextResponse.json(
+      {
+        error: `Workspace webhook limit reached (max ${WEBHOOK_DEFAULTS.MAX_PER_WORKSPACE})`,
+      },
+      { status: 409, headers: rl.headers },
+    );
+  }
+
+  return NextResponse.json(
+    { ...webhook, secret: plainSecret },
+    { status: 201, headers: rl.headers },
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -95,3 +95,22 @@ export const PREFLIGHT = {
   DEFAULT_GAS_LIMIT: 200_000,
   TIMEOUT_MS: 10_000,
 } as const;
+
+export const WEBHOOK_EVENTS = [
+  "anomaly.created",
+  "anomaly.resolved",
+  "validator.jailed",
+  "validator.unjailed",
+  "validator.status_changed",
+  "endpoint.down",
+  "endpoint.recovered",
+  "stats.updated",
+] as const;
+
+export type WebhookEventType = (typeof WEBHOOK_EVENTS)[number];
+
+export const WEBHOOK_DEFAULTS = {
+  MAX_PER_WORKSPACE: 10,
+  MAX_EVENTS: 20,
+  SECRET_PREFIX: "whsec_",
+} as const;

--- a/src/lib/webhook-crypto.ts
+++ b/src/lib/webhook-crypto.ts
@@ -1,0 +1,76 @@
+import { createCipheriv, createDecipheriv, createHmac, randomBytes } from "crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+
+const HEX_64_RE = /^[a-fA-F0-9]{64}$/;
+
+function getEncryptionKey(): Buffer {
+  const hex = process.env.WEBHOOK_ENCRYPTION_KEY;
+  if (!hex || !HEX_64_RE.test(hex)) {
+    throw new Error(
+      "WEBHOOK_ENCRYPTION_KEY must be a 64-character hex string (32 bytes). Generate with: openssl rand -hex 32",
+    );
+  }
+  return Buffer.from(hex, "hex");
+}
+
+/**
+ * Encrypt a webhook signing secret using AES-256-GCM.
+ * Output: base64(iv + authTag + ciphertext)
+ */
+export function encryptSecret(plainSecret: string): string {
+  const key = getEncryptionKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+
+  const encrypted = Buffer.concat([
+    cipher.update(plainSecret, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return Buffer.concat([iv, authTag, encrypted]).toString("base64");
+}
+
+/**
+ * Decrypt a webhook signing secret from AES-256-GCM encrypted form.
+ * Input: base64(iv + authTag + ciphertext)
+ */
+export function decryptSecret(encryptedBase64: string): string {
+  const key = getEncryptionKey();
+  const data = Buffer.from(encryptedBase64, "base64");
+
+  if (data.length < IV_LENGTH + AUTH_TAG_LENGTH + 1) {
+    throw new Error("Invalid encrypted data: too short");
+  }
+
+  const iv = data.subarray(0, IV_LENGTH);
+  const authTag = data.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
+  const ciphertext = data.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  return Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]).toString("utf8");
+}
+
+/**
+ * Sign a payload using HMAC-SHA256.
+ * Used for X-Webhook-Signature header.
+ */
+export function signPayload(secret: string, payload: string): string {
+  return createHmac("sha256", secret).update(payload, "utf8").digest("hex");
+}
+
+/**
+ * Generate a new webhook signing secret.
+ * Format: "whsec_" + 32 random bytes as hex (64 chars)
+ */
+export function generateWebhookSecret(): string {
+  return "whsec_" + randomBytes(32).toString("hex");
+}

--- a/src/lib/webhook-validation.ts
+++ b/src/lib/webhook-validation.ts
@@ -1,0 +1,236 @@
+import { lookup } from "dns/promises";
+import { WEBHOOK_EVENTS, WEBHOOK_DEFAULTS } from "@/lib/constants";
+
+interface WebhookCreateResult {
+  name: string;
+  url: string;
+  events: string[];
+}
+
+interface WebhookUpdateResult {
+  name?: string;
+  url?: string;
+  events?: string[];
+  isActive?: boolean;
+}
+
+interface ValidationError {
+  error: string;
+}
+
+const BLOCKED_HOSTNAMES = new Set([
+  "localhost",
+  "0.0.0.0",
+  "metadata.google.internal",
+  "metadata.google",
+]);
+
+/** Check if a resolved IPv4 address is private/internal */
+export function isBlockedIpv4(ip: string): boolean {
+  if (ip.startsWith("127.")) return true;       // loopback 127.0.0.0/8
+  if (ip.startsWith("10.")) return true;         // RFC 1918
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(ip)) return true; // RFC 1918
+  if (ip.startsWith("192.168.")) return true;    // RFC 1918
+  if (ip.startsWith("169.254.")) return true;    // link-local
+  if (ip === "0.0.0.0") return true;             // unspecified
+  return false;
+}
+
+/** Check if a resolved IPv6 address is private/internal */
+export function isBlockedIpv6(ip: string): boolean {
+  const lower = ip.toLowerCase();
+  if (lower === "::1") return true;              // loopback
+  if (lower.startsWith("fe80:")) return true;    // link-local
+  if (/^f[cd]/i.test(lower)) return true;        // ULA (fc00::/7)
+  // IPv4-mapped IPv6 — dotted form (::ffff:127.0.0.1)
+  if (lower.startsWith("::ffff:") && lower.includes(".")) {
+    return isBlockedIpv4(lower.slice(7));
+  }
+  // IPv4-mapped IPv6 — hex form (::ffff:7f00:1) as parsed by URL()
+  const hexMapped = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (hexMapped) {
+    const hi = parseInt(hexMapped[1], 16);
+    const lo = parseInt(hexMapped[2], 16);
+    const a = (hi >> 8) & 0xff;
+    const b = hi & 0xff;
+    const c = (lo >> 8) & 0xff;
+    const d = lo & 0xff;
+    return isBlockedIpv4(`${a}.${b}.${c}.${d}`);
+  }
+  return false;
+}
+
+/** String-based hostname check (pre-DNS, best-effort) */
+function isBlockedHost(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  // Strip brackets from IPv6 literals
+  const bare = h.startsWith("[") && h.endsWith("]") ? h.slice(1, -1) : h;
+
+  if (BLOCKED_HOSTNAMES.has(bare)) return true;
+  // IPv4 checks
+  if (isBlockedIpv4(bare)) return true;
+  // IPv6 literal checks
+  if (isBlockedIpv6(bare)) return true;
+  // .local / .internal TLDs
+  if (/\.(local|internal)$/i.test(bare)) return true;
+  return false;
+}
+
+function validateUrl(raw: string): string | null {
+  try {
+    const parsed = new URL(raw);
+    if (
+      parsed.protocol !== "https:" &&
+      process.env.NODE_ENV === "production"
+    ) {
+      return "url must use HTTPS in production";
+    }
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      return "url must use HTTP or HTTPS protocol";
+    }
+    if (isBlockedHost(parsed.hostname)) {
+      return "url must not point to private or internal addresses";
+    }
+    return null;
+  } catch {
+    return "url must be a valid URL";
+  }
+}
+
+/**
+ * DNS resolution + IP class check.
+ * Must be called at fetch-time (not at validation-time) to prevent
+ * DNS rebinding and catch hostnames that resolve to private IPs.
+ */
+export async function assertUrlNotPrivate(url: string): Promise<void> {
+  const parsed = new URL(url);
+  const { address, family } = await lookup(parsed.hostname);
+
+  if (family === 4 && isBlockedIpv4(address)) {
+    throw new Error("URL resolves to a blocked private/internal address");
+  }
+  if (family === 6 && isBlockedIpv6(address)) {
+    throw new Error("URL resolves to a blocked private/internal address");
+  }
+}
+
+export function validateWebhookCreate(
+  body: unknown,
+): WebhookCreateResult | ValidationError {
+  if (!body || typeof body !== "object") {
+    return { error: "Request body is required" };
+  }
+
+  const { name, url, events } = body as Record<string, unknown>;
+
+  // name validation
+  if (typeof name !== "string" || name.trim().length === 0) {
+    return { error: "name is required and must be a non-empty string" };
+  }
+  if (name.trim().length > 100) {
+    return { error: "name must be at most 100 characters" };
+  }
+
+  // url validation
+  if (typeof url !== "string" || url.trim().length === 0) {
+    return { error: "url is required and must be a non-empty string" };
+  }
+  const urlError = validateUrl(url.trim());
+  if (urlError) {
+    return { error: urlError };
+  }
+
+  // events validation
+  if (!Array.isArray(events) || events.length === 0) {
+    return { error: "events must be a non-empty array" };
+  }
+  if (events.length > WEBHOOK_DEFAULTS.MAX_EVENTS) {
+    return {
+      error: `events must have at most ${WEBHOOK_DEFAULTS.MAX_EVENTS} items`,
+    };
+  }
+  const validEvents = WEBHOOK_EVENTS as readonly string[];
+  for (const event of events) {
+    if (typeof event !== "string" || !validEvents.includes(event)) {
+      return {
+        error: `Invalid event type: ${String(event)}. Valid types: ${WEBHOOK_EVENTS.join(", ")}`,
+      };
+    }
+  }
+
+  return {
+    name: name.trim(),
+    url: url.trim(),
+    events: events as string[],
+  };
+}
+
+export function validateWebhookUpdate(
+  body: unknown,
+): WebhookUpdateResult | ValidationError {
+  if (!body || typeof body !== "object") {
+    return { error: "Request body is required" };
+  }
+
+  const { name, url, events, isActive } = body as Record<string, unknown>;
+  const result: WebhookUpdateResult = {};
+  let hasField = false;
+
+  if (name !== undefined) {
+    if (typeof name !== "string" || name.trim().length === 0) {
+      return { error: "name must be a non-empty string" };
+    }
+    if (name.trim().length > 100) {
+      return { error: "name must be at most 100 characters" };
+    }
+    result.name = name.trim();
+    hasField = true;
+  }
+
+  if (url !== undefined) {
+    if (typeof url !== "string" || url.trim().length === 0) {
+      return { error: "url must be a non-empty string" };
+    }
+    const urlError = validateUrl(url.trim());
+    if (urlError) {
+      return { error: urlError };
+    }
+    result.url = url.trim();
+    hasField = true;
+  }
+
+  if (events !== undefined) {
+    if (!Array.isArray(events) || events.length === 0) {
+      return { error: "events must be a non-empty array" };
+    }
+    if (events.length > WEBHOOK_DEFAULTS.MAX_EVENTS) {
+      return {
+        error: `events must have at most ${WEBHOOK_DEFAULTS.MAX_EVENTS} items`,
+      };
+    }
+    const validEvents = WEBHOOK_EVENTS as readonly string[];
+    for (const event of events) {
+      if (typeof event !== "string" || !validEvents.includes(event)) {
+        return {
+          error: `Invalid event type: ${String(event)}. Valid types: ${WEBHOOK_EVENTS.join(", ")}`,
+        };
+      }
+    }
+    result.events = events as string[];
+    hasField = true;
+  }
+
+  if (isActive !== undefined) {
+    if (typeof isActive !== "boolean") {
+      return { error: "isActive must be a boolean" };
+    }
+    result.isActive = isActive;
+    hasField = true;
+  }
+
+  if (!hasField) {
+    return { error: "At least one field must be provided for update" };
+  }
+
+  return result;
+}

--- a/tests/unit/api/webhooks.test.ts
+++ b/tests/unit/api/webhooks.test.ts
@@ -1,0 +1,441 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@/lib/db", () => {
+  const webhookModel = {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    count: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+  return {
+    prisma: {
+      webhook: webhookModel,
+      webhookDelivery: {
+        findMany: vi.fn(),
+        count: vi.fn(),
+      },
+      $transaction: vi.fn((fn: (tx: unknown) => unknown) =>
+        fn({ webhook: webhookModel, $queryRaw: vi.fn().mockResolvedValue([]) }),
+      ),
+    },
+  };
+});
+
+vi.mock("@/lib/api-helpers", async () => {
+  return {
+    withRateLimit: vi.fn(() => ({ headers: { "X-RateLimit-Limit": "60" } })),
+    jsonResponse: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/workspace-auth", () => ({
+  requireWorkspace: vi.fn(),
+}));
+
+vi.mock("@/lib/webhook-crypto", () => ({
+  generateWebhookSecret: vi.fn(() => "whsec_" + "ab".repeat(32)),
+  encryptSecret: vi.fn(() => "encrypted-secret-base64"),
+  decryptSecret: vi.fn(() => "whsec_" + "ab".repeat(32)),
+  signPayload: vi.fn(() => "mocked-signature"),
+}));
+
+vi.mock("@/lib/webhook-validation", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/webhook-validation")>();
+  return {
+    ...original,
+    assertUrlNotPrivate: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+import { prisma } from "@/lib/db";
+import { requireWorkspace } from "@/lib/workspace-auth";
+import { assertUrlNotPrivate } from "@/lib/webhook-validation";
+
+const mockWorkspace = { id: "ws-1", name: "Test", slug: "test" };
+
+const mockWebhook = {
+  id: "wh-1",
+  workspaceId: "ws-1",
+  name: "My Webhook",
+  url: "https://example.com/hook",
+  secretEncrypted: "encrypted-secret-base64",
+  events: ["anomaly.created"],
+  isActive: true,
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+};
+
+function authSuccess() {
+  vi.mocked(requireWorkspace).mockResolvedValue({ workspace: mockWorkspace });
+}
+
+function authFail() {
+  vi.mocked(requireWorkspace).mockResolvedValue({
+    error: NextResponse.json(
+      { error: "Unauthorized — valid workspace token required" },
+      { status: 401 },
+    ),
+  });
+}
+
+describe("GET /api/webhooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authSuccess();
+  });
+
+  it("returns webhook list without secret", async () => {
+    const selectResult = [
+      {
+        id: "wh-1",
+        name: "My Webhook",
+        url: "https://example.com/hook",
+        events: ["anomaly.created"],
+        isActive: true,
+        createdAt: new Date("2026-01-01"),
+      },
+    ];
+    vi.mocked(prisma.webhook.findMany).mockResolvedValue(selectResult as never);
+
+    const { GET } = await import("@/app/api/webhooks/route");
+    const req = new NextRequest("http://localhost/api/webhooks", {
+      headers: { Authorization: "Bearer ws_token" },
+    });
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(body.webhooks).toHaveLength(1);
+    expect(body.webhooks[0]).not.toHaveProperty("secretEncrypted");
+    expect(body.webhooks[0].name).toBe("My Webhook");
+  });
+
+  it("returns 401 without auth", async () => {
+    authFail();
+    const { GET } = await import("@/app/api/webhooks/route");
+    const req = new NextRequest("http://localhost/api/webhooks");
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/webhooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authSuccess();
+    vi.mocked(prisma.webhook.count).mockResolvedValue(0);
+    vi.mocked(prisma.webhook.create).mockResolvedValue({
+      id: "wh-new",
+      name: "New Webhook",
+      url: "https://example.com/hook",
+      events: ["anomaly.created"],
+      isActive: true,
+      createdAt: new Date("2026-01-01"),
+    } as never);
+  });
+
+  it("creates webhook and returns secret once", async () => {
+    const { POST } = await import("@/app/api/webhooks/route");
+    const req = new NextRequest("http://localhost/api/webhooks", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer ws_token",
+      },
+      body: JSON.stringify({
+        name: "New Webhook",
+        url: "https://example.com/hook",
+        events: ["anomaly.created"],
+      }),
+    });
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.secret).toMatch(/^whsec_/);
+    expect(body.id).toBe("wh-new");
+  });
+
+  it("returns 400 on invalid body", async () => {
+    const { POST } = await import("@/app/api/webhooks/route");
+    const req = new NextRequest("http://localhost/api/webhooks", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer ws_token",
+      },
+      body: JSON.stringify({ name: "" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 409 when workspace limit reached", async () => {
+    vi.mocked(prisma.webhook.count).mockResolvedValue(10);
+
+    const { POST } = await import("@/app/api/webhooks/route");
+    const req = new NextRequest("http://localhost/api/webhooks", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer ws_token",
+      },
+      body: JSON.stringify({
+        name: "New",
+        url: "https://example.com/hook",
+        events: ["anomaly.created"],
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 400 on invalid JSON", async () => {
+    const { POST } = await import("@/app/api/webhooks/route");
+    const req = new NextRequest("http://localhost/api/webhooks", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer ws_token",
+      },
+      body: "not-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/webhooks/:id", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authSuccess();
+  });
+
+  it("updates webhook fields", async () => {
+    vi.mocked(prisma.webhook.findFirst).mockResolvedValue(mockWebhook as never);
+    vi.mocked(prisma.webhook.update).mockResolvedValue({
+      ...mockWebhook,
+      name: "Updated",
+      updatedAt: new Date(),
+    } as never);
+
+    const { PATCH } = await import("@/app/api/webhooks/[id]/route");
+    const req = new NextRequest("http://localhost/api/webhooks/wh-1", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer ws_token",
+      },
+      body: JSON.stringify({ name: "Updated" }),
+    });
+    const res = await PATCH(req, { params: Promise.resolve({ id: "wh-1" }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.name).toBe("Updated");
+    expect(body).not.toHaveProperty("secret");
+  });
+
+  it("returns 404 on wrong workspace (isolation)", async () => {
+    vi.mocked(prisma.webhook.findFirst).mockResolvedValue(null);
+
+    const { PATCH } = await import("@/app/api/webhooks/[id]/route");
+    const req = new NextRequest("http://localhost/api/webhooks/wh-other", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer ws_token",
+      },
+      body: JSON.stringify({ name: "Updated" }),
+    });
+    const res = await PATCH(req, { params: Promise.resolve({ id: "wh-other" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 on invalid body", async () => {
+    const { PATCH } = await import("@/app/api/webhooks/[id]/route");
+    const req = new NextRequest("http://localhost/api/webhooks/wh-1", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer ws_token",
+      },
+      body: JSON.stringify({}),
+    });
+    const res = await PATCH(req, { params: Promise.resolve({ id: "wh-1" }) });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("DELETE /api/webhooks/:id", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authSuccess();
+  });
+
+  it("deletes webhook and returns 204", async () => {
+    vi.mocked(prisma.webhook.findFirst).mockResolvedValue(mockWebhook as never);
+    vi.mocked(prisma.webhook.delete).mockResolvedValue(mockWebhook as never);
+
+    const { DELETE } = await import("@/app/api/webhooks/[id]/route");
+    const req = new NextRequest("http://localhost/api/webhooks/wh-1", {
+      method: "DELETE",
+      headers: { Authorization: "Bearer ws_token" },
+    });
+    const res = await DELETE(req, { params: Promise.resolve({ id: "wh-1" }) });
+    expect(res.status).toBe(204);
+  });
+
+  it("returns 404 on wrong workspace", async () => {
+    vi.mocked(prisma.webhook.findFirst).mockResolvedValue(null);
+
+    const { DELETE } = await import("@/app/api/webhooks/[id]/route");
+    const req = new NextRequest("http://localhost/api/webhooks/wh-other", {
+      method: "DELETE",
+      headers: { Authorization: "Bearer ws_token" },
+    });
+    const res = await DELETE(req, { params: Promise.resolve({ id: "wh-other" }) });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /api/webhooks/:id/deliveries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authSuccess();
+  });
+
+  it("returns paginated delivery list", async () => {
+    vi.mocked(prisma.webhook.findFirst).mockResolvedValue({ id: "wh-1" } as never);
+    const mockDelivery = {
+      id: "del-1",
+      eventType: "anomaly.created",
+      statusCode: 200,
+      success: true,
+      attempts: 1,
+      deliveredAt: new Date(),
+      createdAt: new Date(),
+    };
+    vi.mocked(prisma.webhookDelivery.findMany).mockResolvedValue([mockDelivery] as never);
+    vi.mocked(prisma.webhookDelivery.count).mockResolvedValue(1);
+
+    const { GET } = await import("@/app/api/webhooks/[id]/deliveries/route");
+    const req = new NextRequest("http://localhost/api/webhooks/wh-1/deliveries", {
+      headers: { Authorization: "Bearer ws_token" },
+    });
+    const res = await GET(req, { params: Promise.resolve({ id: "wh-1" }) });
+    const body = await res.json();
+
+    expect(body.deliveries).toHaveLength(1);
+    expect(body.total).toBe(1);
+  });
+
+  it("returns 404 on wrong workspace", async () => {
+    vi.mocked(prisma.webhook.findFirst).mockResolvedValue(null);
+
+    const { GET } = await import("@/app/api/webhooks/[id]/deliveries/route");
+    const req = new NextRequest("http://localhost/api/webhooks/wh-other/deliveries", {
+      headers: { Authorization: "Bearer ws_token" },
+    });
+    const res = await GET(req, { params: Promise.resolve({ id: "wh-other" }) });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/webhooks/:id/test", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authSuccess();
+  });
+
+  it("sends test request and returns result", async () => {
+    vi.mocked(prisma.webhook.findFirst).mockResolvedValue(mockWebhook as never);
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { POST } = await import("@/app/api/webhooks/[id]/test/route");
+    const req = new NextRequest("http://localhost/api/webhooks/wh-1/test", {
+      method: "POST",
+      headers: { Authorization: "Bearer ws_token" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: "wh-1" }) });
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(body.statusCode).toBe(200);
+    expect(body.responseTime).toBeGreaterThanOrEqual(0);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/hook",
+      expect.objectContaining({
+        method: "POST",
+        redirect: "manual",
+        headers: expect.objectContaining({
+          "X-Webhook-Signature": "mocked-signature",
+          "X-Webhook-Event": "webhook.test",
+        }),
+      }),
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  it("returns 400 when URL resolves to private IP (SSRF)", async () => {
+    vi.mocked(prisma.webhook.findFirst).mockResolvedValue(mockWebhook as never);
+    vi.mocked(assertUrlNotPrivate).mockRejectedValue(
+      new Error("URL resolves to a blocked private/internal address"),
+    );
+
+    const { POST } = await import("@/app/api/webhooks/[id]/test/route");
+    const req = new NextRequest("http://localhost/api/webhooks/wh-1/test", {
+      method: "POST",
+      headers: { Authorization: "Bearer ws_token" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: "wh-1" }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain("blocked");
+
+    // Reset mock
+    vi.mocked(assertUrlNotPrivate).mockResolvedValue(undefined);
+  });
+
+  it("returns 404 on wrong workspace", async () => {
+    vi.mocked(prisma.webhook.findFirst).mockResolvedValue(null);
+
+    const { POST } = await import("@/app/api/webhooks/[id]/test/route");
+    const req = new NextRequest("http://localhost/api/webhooks/wh-other/test", {
+      method: "POST",
+      headers: { Authorization: "Bearer ws_token" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: "wh-other" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("handles fetch error gracefully", async () => {
+    vi.mocked(prisma.webhook.findFirst).mockResolvedValue(mockWebhook as never);
+
+    const mockFetch = vi.fn().mockRejectedValue(new Error("Connection refused"));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { POST } = await import("@/app/api/webhooks/[id]/test/route");
+    const req = new NextRequest("http://localhost/api/webhooks/wh-1/test", {
+      method: "POST",
+      headers: { Authorization: "Bearer ws_token" },
+    });
+    const res = await POST(req, { params: Promise.resolve({ id: "wh-1" }) });
+    const body = await res.json();
+
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Connection refused");
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/tests/unit/lib/webhook-crypto.test.ts
+++ b/tests/unit/lib/webhook-crypto.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const TEST_KEY = "a".repeat(64); // valid 64-char hex
+
+describe("webhook-crypto", () => {
+  const originalEnv = process.env.WEBHOOK_ENCRYPTION_KEY;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.WEBHOOK_ENCRYPTION_KEY = TEST_KEY;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.WEBHOOK_ENCRYPTION_KEY = originalEnv;
+    } else {
+      delete process.env.WEBHOOK_ENCRYPTION_KEY;
+    }
+  });
+
+  it("encryptSecret → decryptSecret roundtrip", async () => {
+    const { encryptSecret, decryptSecret } = await import("@/lib/webhook-crypto");
+    const plain = "whsec_test_secret_123";
+    const encrypted = encryptSecret(plain);
+    const decrypted = decryptSecret(encrypted);
+    expect(decrypted).toBe(plain);
+  });
+
+  it("produces different ciphertext for the same plaintext (random IV)", async () => {
+    const { encryptSecret } = await import("@/lib/webhook-crypto");
+    const plain = "whsec_same_secret";
+    const a = encryptSecret(plain);
+    const b = encryptSecret(plain);
+    expect(a).not.toBe(b);
+  });
+
+  it("throws on invalid ciphertext", async () => {
+    const { decryptSecret } = await import("@/lib/webhook-crypto");
+    expect(() => decryptSecret("not-valid-base64!!!")).toThrow();
+  });
+
+  it("throws on too-short ciphertext", async () => {
+    const { decryptSecret } = await import("@/lib/webhook-crypto");
+    const short = Buffer.alloc(10).toString("base64");
+    expect(() => decryptSecret(short)).toThrow("Invalid encrypted data: too short");
+  });
+
+  it("signPayload is deterministic", async () => {
+    const { signPayload } = await import("@/lib/webhook-crypto");
+    const sig1 = signPayload("secret", "payload");
+    const sig2 = signPayload("secret", "payload");
+    expect(sig1).toBe(sig2);
+    expect(sig1).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("signPayload returns different signatures for different secrets", async () => {
+    const { signPayload } = await import("@/lib/webhook-crypto");
+    const sig1 = signPayload("secret1", "payload");
+    const sig2 = signPayload("secret2", "payload");
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it("generateWebhookSecret has correct format", async () => {
+    const { generateWebhookSecret } = await import("@/lib/webhook-crypto");
+    const secret = generateWebhookSecret();
+    expect(secret).toMatch(/^whsec_[a-f0-9]{64}$/);
+    expect(secret).toHaveLength(70); // "whsec_" (6) + 64 hex chars
+  });
+
+  it("throws when WEBHOOK_ENCRYPTION_KEY is missing", async () => {
+    delete process.env.WEBHOOK_ENCRYPTION_KEY;
+    const { encryptSecret } = await import("@/lib/webhook-crypto");
+    expect(() => encryptSecret("test")).toThrow("WEBHOOK_ENCRYPTION_KEY");
+  });
+
+  it("throws when WEBHOOK_ENCRYPTION_KEY is wrong length", async () => {
+    process.env.WEBHOOK_ENCRYPTION_KEY = "tooshort";
+    const { encryptSecret } = await import("@/lib/webhook-crypto");
+    expect(() => encryptSecret("test")).toThrow("WEBHOOK_ENCRYPTION_KEY");
+  });
+
+  it("throws when WEBHOOK_ENCRYPTION_KEY has non-hex characters", async () => {
+    process.env.WEBHOOK_ENCRYPTION_KEY = "z".repeat(64);
+    const { encryptSecret } = await import("@/lib/webhook-crypto");
+    expect(() => encryptSecret("test")).toThrow("WEBHOOK_ENCRYPTION_KEY");
+  });
+});

--- a/tests/unit/lib/webhook-validation.test.ts
+++ b/tests/unit/lib/webhook-validation.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { validateWebhookCreate, validateWebhookUpdate, assertUrlNotPrivate } from "@/lib/webhook-validation";
+
+vi.mock("dns/promises", () => {
+  const lookup = vi.fn();
+  return { default: { lookup }, lookup };
+});
+
+describe("validateWebhookCreate", () => {
+  const validBody = {
+    name: "My Webhook",
+    url: "https://example.com/hook",
+    events: ["anomaly.created"],
+  };
+
+  it("accepts valid create body", () => {
+    const result = validateWebhookCreate(validBody);
+    expect(result).toEqual({
+      name: "My Webhook",
+      url: "https://example.com/hook",
+      events: ["anomaly.created"],
+    });
+  });
+
+  it("trims name and url", () => {
+    const result = validateWebhookCreate({
+      ...validBody,
+      name: "  Trimmed  ",
+      url: "  https://example.com/hook  ",
+    });
+    expect(result).toEqual(
+      expect.objectContaining({ name: "Trimmed", url: "https://example.com/hook" }),
+    );
+  });
+
+  it("rejects null body", () => {
+    const result = validateWebhookCreate(null);
+    expect(result).toEqual({ error: "Request body is required" });
+  });
+
+  it("rejects missing name", () => {
+    const result = validateWebhookCreate({ url: "https://x.com", events: ["anomaly.created"] });
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("name");
+  });
+
+  it("rejects empty name", () => {
+    const result = validateWebhookCreate({ ...validBody, name: "   " });
+    expect(result).toHaveProperty("error");
+  });
+
+  it("rejects name over 100 chars", () => {
+    const result = validateWebhookCreate({ ...validBody, name: "x".repeat(101) });
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("100");
+  });
+
+  it("rejects invalid URL", () => {
+    const result = validateWebhookCreate({ ...validBody, url: "not-a-url" });
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("url");
+  });
+
+  it("rejects non-http(s) protocol", () => {
+    const result = validateWebhookCreate({ ...validBody, url: "ftp://example.com" });
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("protocol");
+  });
+
+  it("rejects empty events array", () => {
+    const result = validateWebhookCreate({ ...validBody, events: [] });
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("events");
+  });
+
+  it("rejects non-array events", () => {
+    const result = validateWebhookCreate({ ...validBody, events: "anomaly.created" });
+    expect(result).toHaveProperty("error");
+  });
+
+  it("rejects invalid event type", () => {
+    const result = validateWebhookCreate({ ...validBody, events: ["invalid.event"] });
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("Invalid event type");
+  });
+
+  it("rejects events over MAX_EVENTS limit", () => {
+    const events = Array(21).fill("anomaly.created");
+    const result = validateWebhookCreate({ ...validBody, events });
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("20");
+  });
+
+  it("accepts multiple valid event types", () => {
+    const result = validateWebhookCreate({
+      ...validBody,
+      events: ["anomaly.created", "validator.jailed", "endpoint.down"],
+    });
+    expect(result).not.toHaveProperty("error");
+    expect((result as { events: string[] }).events).toHaveLength(3);
+  });
+
+  describe("SSRF protection — string-based", () => {
+    it.each([
+      ["http://localhost/hook", "localhost"],
+      ["http://127.0.0.1/hook", "loopback IPv4"],
+      ["http://127.0.0.2/hook", "loopback range"],
+      ["http://127.255.0.1/hook", "loopback range high"],
+      ["http://0.0.0.0/hook", "unspecified IPv4"],
+      ["http://[::1]/hook", "loopback IPv6"],
+      ["http://[fe80::1]/hook", "link-local IPv6"],
+      ["http://[fc00::1]/hook", "ULA IPv6 (fc)"],
+      ["http://[fd12::1]/hook", "ULA IPv6 (fd)"],
+      ["http://[::ffff:127.0.0.1]/hook", "IPv4-mapped IPv6 loopback"],
+      ["http://[::ffff:10.0.0.1]/hook", "IPv4-mapped IPv6 private"],
+      ["http://10.0.0.1/hook", "10.x private"],
+      ["http://172.16.0.1/hook", "172.16.x private"],
+      ["http://192.168.1.1/hook", "192.168.x private"],
+      ["http://169.254.169.254/hook", "link-local / cloud metadata"],
+      ["http://metadata.google.internal/hook", "GCP metadata"],
+      ["http://service.local/hook", ".local TLD"],
+      ["http://app.internal/hook", ".internal TLD"],
+    ])("rejects %s (%s)", (url) => {
+      const result = validateWebhookCreate({ ...validBody, url });
+      expect(result).toHaveProperty("error");
+      expect((result as { error: string }).error).toContain("private or internal");
+    });
+  });
+});
+
+describe("validateWebhookUpdate", () => {
+  it("accepts partial update with name only", () => {
+    const result = validateWebhookUpdate({ name: "Updated" });
+    expect(result).toEqual({ name: "Updated" });
+  });
+
+  it("accepts partial update with isActive only", () => {
+    const result = validateWebhookUpdate({ isActive: false });
+    expect(result).toEqual({ isActive: false });
+  });
+
+  it("accepts full update", () => {
+    const result = validateWebhookUpdate({
+      name: "Updated",
+      url: "https://new.example.com/hook",
+      events: ["anomaly.resolved"],
+      isActive: true,
+    });
+    expect(result).toEqual({
+      name: "Updated",
+      url: "https://new.example.com/hook",
+      events: ["anomaly.resolved"],
+      isActive: true,
+    });
+  });
+
+  it("rejects empty body", () => {
+    const result = validateWebhookUpdate({});
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("At least one field");
+  });
+
+  it("rejects null body", () => {
+    const result = validateWebhookUpdate(null);
+    expect(result).toEqual({ error: "Request body is required" });
+  });
+
+  it("rejects invalid isActive type", () => {
+    const result = validateWebhookUpdate({ isActive: "yes" });
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toContain("isActive");
+  });
+
+  it("rejects invalid name in update", () => {
+    const result = validateWebhookUpdate({ name: "" });
+    expect(result).toHaveProperty("error");
+  });
+
+  it("validates url in update", () => {
+    const result = validateWebhookUpdate({ url: "not-valid" });
+    expect(result).toHaveProperty("error");
+  });
+
+  it("validates events in update", () => {
+    const result = validateWebhookUpdate({ events: ["fake.event"] });
+    expect(result).toHaveProperty("error");
+  });
+});
+
+describe("assertUrlNotPrivate — DNS resolution check", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes for public IPv4", async () => {
+    const { lookup } = await import("dns/promises");
+    vi.mocked(lookup).mockResolvedValue({ address: "93.184.216.34", family: 4 } as never);
+    await expect(assertUrlNotPrivate("https://example.com/hook")).resolves.toBeUndefined();
+  });
+
+  it("rejects when DNS resolves to loopback IPv4", async () => {
+    const { lookup } = await import("dns/promises");
+    vi.mocked(lookup).mockResolvedValue({ address: "127.0.0.1", family: 4 } as never);
+    await expect(assertUrlNotPrivate("https://evil.com/hook")).rejects.toThrow("blocked");
+  });
+
+  it("rejects when DNS resolves to private IPv4 (10.x)", async () => {
+    const { lookup } = await import("dns/promises");
+    vi.mocked(lookup).mockResolvedValue({ address: "10.0.0.5", family: 4 } as never);
+    await expect(assertUrlNotPrivate("https://evil.com/hook")).rejects.toThrow("blocked");
+  });
+
+  it("rejects when DNS resolves to private IPv4 (192.168.x)", async () => {
+    const { lookup } = await import("dns/promises");
+    vi.mocked(lookup).mockResolvedValue({ address: "192.168.1.100", family: 4 } as never);
+    await expect(assertUrlNotPrivate("https://evil.com/hook")).rejects.toThrow("blocked");
+  });
+
+  it("rejects when DNS resolves to link-local IPv4", async () => {
+    const { lookup } = await import("dns/promises");
+    vi.mocked(lookup).mockResolvedValue({ address: "169.254.169.254", family: 4 } as never);
+    await expect(assertUrlNotPrivate("https://evil.com/hook")).rejects.toThrow("blocked");
+  });
+
+  it("rejects when DNS resolves to IPv6 loopback", async () => {
+    const { lookup } = await import("dns/promises");
+    vi.mocked(lookup).mockResolvedValue({ address: "::1", family: 6 } as never);
+    await expect(assertUrlNotPrivate("https://evil.com/hook")).rejects.toThrow("blocked");
+  });
+
+  it("rejects when DNS resolves to IPv6 link-local", async () => {
+    const { lookup } = await import("dns/promises");
+    vi.mocked(lookup).mockResolvedValue({ address: "fe80::1", family: 6 } as never);
+    await expect(assertUrlNotPrivate("https://evil.com/hook")).rejects.toThrow("blocked");
+  });
+
+  it("rejects when DNS resolves to IPv6 ULA", async () => {
+    const { lookup } = await import("dns/promises");
+    vi.mocked(lookup).mockResolvedValue({ address: "fd12::1", family: 6 } as never);
+    await expect(assertUrlNotPrivate("https://evil.com/hook")).rejects.toThrow("blocked");
+  });
+
+  it("rejects when DNS resolves to IPv4-mapped IPv6 private", async () => {
+    const { lookup } = await import("dns/promises");
+    vi.mocked(lookup).mockResolvedValue({ address: "::ffff:10.0.0.1", family: 6 } as never);
+    await expect(assertUrlNotPrivate("https://evil.com/hook")).rejects.toThrow("blocked");
+  });
+
+  it("passes for public IPv6", async () => {
+    const { lookup } = await import("dns/promises");
+    vi.mocked(lookup).mockResolvedValue({ address: "2606:4700::6810:84e5", family: 6 } as never);
+    await expect(assertUrlNotPrivate("https://example.com/hook")).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **Prisma schema**: 4 new models (Webhook, WebhookDelivery, OutboxEvent, WebhookCursor) + Workspace relation
- **Webhook CRUD API**: workspace-scoped GET/POST/PATCH/DELETE with rate limiting and auth
- **Security**: AES-256-GCM secret encryption, SSRF protection (string-based + DNS resolution + redirect:manual), atomic limit enforcement via `SELECT ... FOR UPDATE`
- **Test endpoint**: POST /api/webhooks/:id/test with HMAC-SHA256 signed delivery
- **Delivery history**: paginated GET /api/webhooks/:id/deliveries

### Security highlights
- Webhook signing secret encrypted at rest, returned only once at creation
- Private IP/hostname blocking: loopback, RFC 1918, link-local, IPv6 ULA/link-local, IPv4-mapped IPv6 (dotted + hex form), .local/.internal TLD
- DNS resolution check at fetch-time to catch hostnames resolving to private IPs
- `redirect: manual` prevents redirect-based SSRF
- Workspace row lock (`FOR UPDATE`) prevents race condition on webhook limit

### Files changed (13)
| File | Change |
|------|--------|
| `prisma/schema.prisma` | +4 models, Workspace relation |
| `prisma/migrations/20260312.../migration.sql` | DDL + WebhookCursor seed |
| `src/lib/webhook-crypto.ts` | AES-256-GCM encrypt/decrypt, HMAC sign, secret generation |
| `src/lib/webhook-validation.ts` | Request validation + SSRF URL blocking + DNS resolution check |
| `src/lib/constants.ts` | WEBHOOK_EVENTS (8 types) + WEBHOOK_DEFAULTS |
| `src/app/api/webhooks/route.ts` | GET + POST (with atomic limit) |
| `src/app/api/webhooks/[id]/route.ts` | PATCH + DELETE |
| `src/app/api/webhooks/[id]/deliveries/route.ts` | GET (paginated) |
| `src/app/api/webhooks/[id]/test/route.ts` | POST (test delivery with DNS check) |
| `.env.example` | +WEBHOOK_ENCRYPTION_KEY |
| `tests/unit/lib/webhook-crypto.test.ts` | 10 tests |
| `tests/unit/lib/webhook-validation.test.ts` | 50 tests |
| `tests/unit/api/webhooks.test.ts` | 17 tests |

## Test plan

- [x] `npx prisma generate` — new models in client
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 321/321 passed (244 existing + 77 new)
- [x] `npm run build` — clean production build