### PR TITLE
fix(indexer): align validator sync batching and transaction timeout

### DIFF
--- a/src/lib/indexer/validators.ts
+++ b/src/lib/indexer/validators.ts
@@ -13,7 +13,8 @@ interface SyncResult {
   duration: number;
 }
 
-const BATCH_SIZE = 50;
+const BATCH_SIZE = 25;
+const TX_TIMEOUT_MS = 15_000;
 
 export async function syncValidators(
   options: SyncOptions = {},
@@ -98,7 +99,7 @@ export async function syncValidators(
             snapshotsCreated++;
           }
         }
-      });
+      }, { timeout: TX_TIMEOUT_MS });
     }
 
     return {


### PR DESCRIPTION
## Summary

- `src/lib/indexer/validators.ts` had stale values (`BATCH_SIZE=50`, default 5s transaction timeout) that diverged from the cron script fix in `2e3d1df`
- Aligns both paths to identical parameters: `BATCH_SIZE=25`, `TX_TIMEOUT_MS=15_000`
- Prevents P2028 transaction timeout errors when the library path is invoked instead of the standalone cron script

## Changes

| Parameter | Before | After |
|-----------|--------|-------|
| `BATCH_SIZE` | 50 | 25 |
| `TX_TIMEOUT_MS` | _(none, default 5s)_ | 15,000 ms |

## Test plan

- [x] `tsc --noEmit` — no type errors
- [x] 321/321 unit tests passing
- [ ] Monitor 2-3 scheduled cron runs after merge to confirm stability