### PR TITLE
feat(events): durable event outbox + SSE streaming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,11 @@ PANOPTES_ADMIN_TOKEN="ws_change-me-to-a-strong-random-string"
 # Generate with: openssl rand -hex 32
 WEBHOOK_ENCRYPTION_KEY="change-me-to-a-64-char-hex-string"
 
+# ── Stream Token ────────────────────────────────────────────
+# HMAC-SHA256 secret for signing SSE stream tokens
+# Generate with: openssl rand -hex 32
+STREAM_TOKEN_SECRET="change-me-to-a-strong-random-string"
+
 # ── Application ────────────────────────────────────────────────
 # Public URL (used for CORS, sitemap, OG images)
 NEXT_PUBLIC_APP_URL="http://localhost:3000"

--- a/src/app/api/stream/public/route.ts
+++ b/src/app/api/stream/public/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { getClientIp } from "@/lib/api-helpers";
+import { STREAM_DEFAULTS } from "@/lib/constants";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function GET(request: NextRequest) {
+  const ip = getClientIp(request);
+  const limit = checkRateLimit(ip);
+  if (!limit.allowed) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const channelsParam = request.nextUrl.searchParams.get("channels");
+  const channels = channelsParam
+    ? channelsParam.split(",").map((c) => c.trim()).filter(Boolean)
+    : null;
+
+  // Single source of truth: base filter used by both tail cursor and poll
+  const baseFilter: Record<string, unknown> = { visibility: "public" };
+  if (channels) {
+    baseFilter.channel = { in: channels };
+  }
+
+  const lastEventId = request.headers.get("last-event-id");
+  let lastSeq: number;
+
+  if (lastEventId) {
+    lastSeq = parseInt(lastEventId, 10);
+    if (isNaN(lastSeq)) lastSeq = 0;
+  } else {
+    // Tail mode: cursor scoped to exactly the events this client can see
+    const latest = await prisma.outboxEvent.findFirst({
+      where: baseFilter,
+      orderBy: { seq: "desc" },
+      select: { seq: true },
+    });
+    lastSeq = latest?.seq ?? 0;
+  }
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      let currentSeq = lastSeq;
+      let aborted = false;
+
+      request.signal.addEventListener("abort", () => {
+        aborted = true;
+      });
+
+      const run = async () => {
+        // Send initial heartbeat so client knows connection is alive
+        try {
+          controller.enqueue(encoder.encode(": heartbeat\n\n"));
+        } catch {
+          return;
+        }
+
+        let heartbeatCounter = 0;
+
+        while (!aborted) {
+          try {
+            const events = await prisma.outboxEvent.findMany({
+              where: { seq: { gt: currentSeq }, ...baseFilter },
+              orderBy: { seq: "asc" },
+              take: STREAM_DEFAULTS.BATCH_SIZE,
+            });
+
+            for (const event of events) {
+              const data = `id: ${event.seq}\nevent: ${event.type}\ndata: ${event.payload}\n\n`;
+              controller.enqueue(encoder.encode(data));
+              currentSeq = event.seq;
+            }
+          } catch (error) {
+            console.error("[SSE/public] Poll error:", error);
+          }
+
+          // Heartbeat every ~5 poll cycles (15s)
+          heartbeatCounter++;
+          if (heartbeatCounter >= 5) {
+            heartbeatCounter = 0;
+            try {
+              controller.enqueue(encoder.encode(": heartbeat\n\n"));
+            } catch {
+              break;
+            }
+          }
+
+          await sleep(STREAM_DEFAULTS.POLL_INTERVAL_MS);
+        }
+
+        try {
+          controller.close();
+        } catch {
+          // Already closed
+        }
+      };
+
+      run();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/src/app/api/stream/route.ts
+++ b/src/app/api/stream/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { verifyStreamToken } from "@/lib/stream-token";
+import { STREAM_DEFAULTS } from "@/lib/constants";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function GET(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get("token");
+  if (!token) {
+    return NextResponse.json(
+      { error: "Missing token query parameter" },
+      { status: 401 },
+    );
+  }
+
+  const result = verifyStreamToken(token);
+  if (!result.valid) {
+    return NextResponse.json({ error: result.error }, { status: 401 });
+  }
+
+  const workspaceId = result.workspaceId;
+
+  const channelsParam = request.nextUrl.searchParams.get("channels");
+  const channels = channelsParam
+    ? channelsParam.split(",").map((c) => c.trim()).filter(Boolean)
+    : null;
+
+  // Single source of truth: base filter used by both tail cursor and poll
+  const baseFilter: Record<string, unknown> = {
+    OR: [
+      { visibility: "public" },
+      { visibility: "workspace", workspaceId },
+    ],
+  };
+  if (channels) {
+    baseFilter.channel = { in: channels };
+  }
+
+  const lastEventId = request.headers.get("last-event-id");
+  let lastSeq: number;
+
+  if (lastEventId) {
+    lastSeq = parseInt(lastEventId, 10);
+    if (isNaN(lastSeq)) lastSeq = 0;
+  } else {
+    // Tail mode: cursor scoped to exactly the events this client can see
+    const latest = await prisma.outboxEvent.findFirst({
+      where: baseFilter,
+      orderBy: { seq: "desc" },
+      select: { seq: true },
+    });
+    lastSeq = latest?.seq ?? 0;
+  }
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      let currentSeq = lastSeq;
+      let aborted = false;
+
+      request.signal.addEventListener("abort", () => {
+        aborted = true;
+      });
+
+      const run = async () => {
+        // Send initial heartbeat so client knows connection is alive
+        try {
+          controller.enqueue(encoder.encode(": heartbeat\n\n"));
+        } catch {
+          return;
+        }
+
+        let heartbeatCounter = 0;
+
+        while (!aborted) {
+          try {
+            const events = await prisma.outboxEvent.findMany({
+              where: { seq: { gt: currentSeq }, ...baseFilter },
+              orderBy: { seq: "asc" },
+              take: STREAM_DEFAULTS.BATCH_SIZE,
+            });
+
+            for (const event of events) {
+              const data = `id: ${event.seq}\nevent: ${event.type}\ndata: ${event.payload}\n\n`;
+              controller.enqueue(encoder.encode(data));
+              currentSeq = event.seq;
+            }
+          } catch (error) {
+            console.error("[SSE/auth] Poll error:", error);
+          }
+
+          // Heartbeat every ~5 poll cycles (15s)
+          heartbeatCounter++;
+          if (heartbeatCounter >= 5) {
+            heartbeatCounter = 0;
+            try {
+              controller.enqueue(encoder.encode(": heartbeat\n\n"));
+            } catch {
+              break;
+            }
+          }
+
+          await sleep(STREAM_DEFAULTS.POLL_INTERVAL_MS);
+        }
+
+        try {
+          controller.close();
+        } catch {
+          // Already closed
+        }
+      };
+
+      run();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/src/app/api/stream/token/route.ts
+++ b/src/app/api/stream/token/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withRateLimit } from "@/lib/api-helpers";
+import {
+  authenticateWorkspace,
+  extractApiKey,
+} from "@/lib/workspace-auth";
+import { createStreamToken } from "@/lib/stream-token";
+import { STREAM_DEFAULTS } from "@/lib/constants";
+
+export async function POST(request: NextRequest) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  // Try Bearer token first, then fall back to x-api-key header.
+  // This is a compatibility bridge for SDK/external clients until
+  // the dedicated ApiKey model lands in v1.3.1.
+  let workspace = await authenticateWorkspace(request);
+
+  if (!workspace) {
+    const apiKey = extractApiKey(request);
+    if (apiKey) {
+      // Re-use the same auth pipeline with the API key value
+      const syntheticReq = new NextRequest(request.url, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      workspace = await authenticateWorkspace(syntheticReq);
+    }
+  }
+
+  if (!workspace) {
+    return NextResponse.json(
+      { error: "Unauthorized — valid workspace token or API key required" },
+      { status: 401, headers: rl.headers },
+    );
+  }
+
+  const token = createStreamToken(
+    workspace.id,
+    STREAM_DEFAULTS.TOKEN_TTL_SECONDS,
+  );
+
+  return NextResponse.json(
+    { token, expiresIn: STREAM_DEFAULTS.TOKEN_TTL_SECONDS },
+    { headers: rl.headers },
+  );
+}

--- a/src/hooks/use-event-stream.ts
+++ b/src/hooks/use-event-stream.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSWRConfig } from "swr";
+
+export const DEFAULT_REVALIDATE_MAP: Record<string, string[]> = {
+  "anomaly.created": ["/api/anomalies"],
+  "anomaly.resolved": ["/api/anomalies"],
+  "validator.jailed": ["/api/validators", "/api/anomalies"],
+  "validator.unjailed": ["/api/validators", "/api/anomalies"],
+  "endpoint.down": ["/api/endpoints", "/api/anomalies"],
+  "endpoint.recovered": ["/api/endpoints", "/api/anomalies"],
+  "stats.updated": ["/api/stats"],
+};
+
+interface UseEventStreamOptions {
+  url: string;
+  enabled?: boolean;
+  revalidateMap?: Record<string, string[]>;
+  onEvent?: (type: string, data: string) => void;
+  onError?: (error: Event) => void;
+}
+
+export function useEventStream({
+  url,
+  enabled = true,
+  revalidateMap = DEFAULT_REVALIDATE_MAP,
+  onEvent,
+  onError,
+}: UseEventStreamOptions) {
+  const { mutate } = useSWRConfig();
+  const esRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const es = new EventSource(url);
+    esRef.current = es;
+
+    const eventTypes = Object.keys(revalidateMap);
+
+    const handler = (type: string) => (event: MessageEvent) => {
+      onEvent?.(type, event.data);
+      const keys = revalidateMap[type];
+      if (keys) {
+        keys.forEach((key) => mutate(key));
+      }
+    };
+
+    const handlers = eventTypes.map((type) => {
+      const h = handler(type);
+      es.addEventListener(type, h);
+      return { type, handler: h };
+    });
+
+    es.onerror = (event) => {
+      onError?.(event);
+    };
+
+    return () => {
+      handlers.forEach(({ type, handler: h }) =>
+        es.removeEventListener(type, h),
+      );
+      es.close();
+      esRef.current = null;
+    };
+  }, [url, enabled, revalidateMap, onEvent, onError, mutate]);
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -114,3 +114,14 @@ export const WEBHOOK_DEFAULTS = {
   MAX_EVENTS: 20,
   SECRET_PREFIX: "whsec_",
 } as const;
+
+export const STREAM_DEFAULTS = {
+  POLL_INTERVAL_MS: 3_000,
+  HEARTBEAT_MS: 15_000,
+  BATCH_SIZE: 50,
+  TOKEN_TTL_SECONDS: 300,
+} as const;
+
+export const OUTBOX_RETENTION = {
+  HOURS: 24,
+} as const;

--- a/src/lib/events/event-types.ts
+++ b/src/lib/events/event-types.ts
@@ -1,0 +1,36 @@
+import type { WebhookEventType } from "@/lib/constants";
+
+export const CHANNELS = {
+  NETWORK: "network",
+  ANOMALY: "anomaly",
+  WORKSPACE: "workspace",
+} as const;
+
+export type Channel = (typeof CHANNELS)[keyof typeof CHANNELS];
+export type EventVisibility = "public" | "workspace";
+
+export const ANOMALY_CREATE_EVENT_MAP: Record<string, WebhookEventType[]> = {
+  jailing: ["anomaly.created", "validator.jailed"],
+  endpoint_down: ["anomaly.created", "endpoint.down"],
+  large_stake_change: ["anomaly.created"],
+  commission_spike: ["anomaly.created"],
+  block_stale: ["anomaly.created"],
+  mass_unbonding: ["anomaly.created"],
+};
+
+export const ANOMALY_RESOLVE_EVENT_MAP: Record<string, WebhookEventType[]> = {
+  jailing: ["anomaly.resolved", "validator.unjailed"],
+  endpoint_down: ["anomaly.resolved", "endpoint.recovered"],
+  large_stake_change: ["anomaly.resolved"],
+  commission_spike: ["anomaly.resolved"],
+  block_stale: ["anomaly.resolved"],
+  mass_unbonding: ["anomaly.resolved"],
+};
+
+export interface PublishEventInput {
+  channel: Channel;
+  type: WebhookEventType;
+  visibility?: EventVisibility;
+  workspaceId?: string | null;
+  payload: Record<string, unknown>;
+}

--- a/src/lib/events/publish.ts
+++ b/src/lib/events/publish.ts
@@ -1,0 +1,29 @@
+import { prisma } from "@/lib/db";
+import type { PublishEventInput } from "./event-types";
+
+export async function publishEvent(
+  input: PublishEventInput,
+): Promise<number | null> {
+  try {
+    const event = await prisma.outboxEvent.create({
+      data: {
+        channel: input.channel,
+        type: input.type,
+        visibility: input.visibility ?? "public",
+        workspaceId: input.workspaceId ?? null,
+        payload: JSON.stringify(input.payload),
+      },
+      select: { seq: true },
+    });
+    return event.seq;
+  } catch (error) {
+    console.error("[publishEvent] Failed:", error);
+    return null;
+  }
+}
+
+export async function publishEvents(
+  inputs: PublishEventInput[],
+): Promise<void> {
+  await Promise.allSettled(inputs.map(publishEvent));
+}

--- a/src/lib/indexer/cleanup.ts
+++ b/src/lib/indexer/cleanup.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/db";
-import { RETENTION } from "@/lib/constants";
+import { RETENTION, OUTBOX_RETENTION } from "@/lib/constants";
 import { IndexerError } from "@/lib/errors";
 
 export async function cleanupOldData(): Promise<{
@@ -9,6 +9,7 @@ export async function cleanupOldData(): Promise<{
   deletedScores: number;
   deletedValidatorScores: number;
   deletedAnomalies: number;
+  deletedOutboxEvents: number;
   duration: number;
 }> {
   const start = Date.now();
@@ -31,8 +32,9 @@ export async function cleanupOldData(): Promise<{
 
     const scoreCutoff = new Date(Date.now() - 7 * 86400000);
     const anomalyCutoff = new Date(Date.now() - 30 * 86400000);
+    const outboxCutoff = new Date(Date.now() - OUTBOX_RETENTION.HOURS * 3600_000);
 
-    const [snapshots, healthChecks, stats, scores, vScores, anomalies] = await prisma.$transaction([
+    const [snapshots, healthChecks, stats, scores, vScores, anomalies, outboxEvents] = await prisma.$transaction([
       prisma.validatorSnapshot.deleteMany({
         where: { timestamp: { lt: snapshotCutoff } },
       }),
@@ -51,6 +53,9 @@ export async function cleanupOldData(): Promise<{
       prisma.anomaly.deleteMany({
         where: { resolved: true, resolvedAt: { lt: anomalyCutoff } },
       }),
+      prisma.outboxEvent.deleteMany({
+        where: { createdAt: { lt: outboxCutoff } },
+      }),
     ]);
 
     return {
@@ -60,6 +65,7 @@ export async function cleanupOldData(): Promise<{
       deletedScores: scores.count,
       deletedValidatorScores: vScores.count,
       deletedAnomalies: anomalies.count,
+      deletedOutboxEvents: outboxEvents.count,
       duration: Date.now() - start,
     };
   } catch (error) {

--- a/src/lib/indexer/stats.ts
+++ b/src/lib/indexer/stats.ts
@@ -1,6 +1,8 @@
 import { prisma } from "@/lib/db";
 import { getRepublicClient } from "@/lib/republic";
 import { IndexerError } from "@/lib/errors";
+import { publishEvent } from "@/lib/events/publish";
+import { CHANNELS } from "@/lib/events/event-types";
 
 export async function aggregateStats(): Promise<{
   blockHeight: string;
@@ -69,6 +71,19 @@ export async function aggregateStats(): Promise<{
         totalStaked,
         bondedRatio,
         blockHeight,
+        avgBlockTime,
+      },
+    });
+
+    await publishEvent({
+      channel: CHANNELS.NETWORK,
+      type: "stats.updated",
+      payload: {
+        blockHeight: blockHeight.toString(),
+        totalValidators,
+        activeValidators,
+        totalStaked,
+        bondedRatio,
         avgBlockTime,
       },
     });

--- a/src/lib/intelligence/anomaly.ts
+++ b/src/lib/intelligence/anomaly.ts
@@ -1,6 +1,12 @@
 import { prisma } from "@/lib/db";
 import { ANOMALY_THRESHOLDS } from "@/lib/constants";
 import type { AnomalySeverity } from "@/types";
+import { publishEvents } from "@/lib/events/publish";
+import {
+  CHANNELS,
+  ANOMALY_CREATE_EVENT_MAP,
+  ANOMALY_RESOLVE_EVENT_MAP,
+} from "@/lib/events/event-types";
 
 interface DetectionResult {
   detected: number;
@@ -39,6 +45,23 @@ async function createOrSkipAnomaly(params: {
     },
   });
 
+  const eventTypes = ANOMALY_CREATE_EVENT_MAP[params.type] ?? ["anomaly.created"];
+  await publishEvents(
+    eventTypes.map((type) => ({
+      channel: CHANNELS.ANOMALY,
+      type,
+      payload: {
+        anomalyType: params.type,
+        severity: params.severity,
+        entityType: params.entityType,
+        entityId: params.entityId,
+        title: params.title,
+        description: params.description,
+        metadata: params.metadata ?? null,
+      },
+    })),
+  );
+
   return true;
 }
 
@@ -54,6 +77,18 @@ async function resolveAnomalies(type: string, entityId: string | null): Promise<
       resolvedAt: new Date(),
     },
   });
+
+  if (result.count > 0) {
+    const eventTypes = ANOMALY_RESOLVE_EVENT_MAP[type] ?? ["anomaly.resolved"];
+    await publishEvents(
+      eventTypes.map((evType) => ({
+        channel: CHANNELS.ANOMALY,
+        type: evType,
+        payload: { anomalyType: type, entityId, resolvedCount: result.count },
+      })),
+    );
+  }
+
   return result.count;
 }
 

--- a/src/lib/stream-token.ts
+++ b/src/lib/stream-token.ts
@@ -1,0 +1,85 @@
+import { createHmac, timingSafeEqual } from "crypto";
+import { STREAM_DEFAULTS } from "@/lib/constants";
+
+function getSecret(): string {
+  const secret = process.env.STREAM_TOKEN_SECRET;
+  if (!secret || secret.length < 32) {
+    throw new Error(
+      "STREAM_TOKEN_SECRET must be at least 32 characters. Generate with: openssl rand -hex 32",
+    );
+  }
+  return secret;
+}
+
+function toBase64Url(data: string): string {
+  return Buffer.from(data, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function fromBase64Url(b64: string): string {
+  const padded = b64.replace(/-/g, "+").replace(/_/g, "/");
+  return Buffer.from(padded, "base64").toString("utf8");
+}
+
+function sign(payload: string, secret: string): string {
+  return createHmac("sha256", secret)
+    .update(payload, "utf8")
+    .digest("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export function createStreamToken(
+  workspaceId: string,
+  ttlSeconds: number = STREAM_DEFAULTS.TOKEN_TTL_SECONDS,
+): string {
+  const secret = getSecret();
+  const payload = JSON.stringify({
+    wid: workspaceId,
+    exp: Math.floor(Date.now() / 1000) + ttlSeconds,
+  });
+  const encodedPayload = toBase64Url(payload);
+  const signature = sign(encodedPayload, secret);
+  return `${encodedPayload}.${signature}`;
+}
+
+export function verifyStreamToken(
+  token: string,
+): { valid: true; workspaceId: string } | { valid: false; error: string } {
+  const secret = getSecret();
+
+  const dotIndex = token.indexOf(".");
+  if (dotIndex === -1) {
+    return { valid: false, error: "Malformed token" };
+  }
+
+  const encodedPayload = token.slice(0, dotIndex);
+  const providedSig = token.slice(dotIndex + 1);
+
+  const expectedSig = sign(encodedPayload, secret);
+
+  const sigA = Buffer.from(providedSig, "utf8");
+  const sigB = Buffer.from(expectedSig, "utf8");
+  if (sigA.length !== sigB.length || !timingSafeEqual(sigA, sigB)) {
+    return { valid: false, error: "Invalid signature" };
+  }
+
+  try {
+    const payload = JSON.parse(fromBase64Url(encodedPayload)) as {
+      wid: string;
+      exp: number;
+    };
+
+    if (payload.exp < Math.floor(Date.now() / 1000)) {
+      return { valid: false, error: "Token expired" };
+    }
+
+    return { valid: true, workspaceId: payload.wid };
+  } catch {
+    return { valid: false, error: "Invalid payload" };
+  }
+}

--- a/src/lib/workspace-auth.ts
+++ b/src/lib/workspace-auth.ts
@@ -28,6 +28,17 @@ export function extractBearerToken(request: NextRequest): string | null {
 }
 
 /**
+ * Extract API key from x-api-key header.
+ * Used as fallback auth for SDK/external clients.
+ */
+export function extractApiKey(request: NextRequest): string | null {
+  const key = request.headers.get("x-api-key");
+  if (!key) return null;
+  const trimmed = key.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
  * Authenticate a request using workspace Bearer token.
  *
  * Flow:

--- a/tests/unit/api/stream.test.ts
+++ b/tests/unit/api/stream.test.ts
@@ -1,0 +1,502 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    outboxEvent: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/api-helpers", () => ({
+  withRateLimit: vi.fn(() => ({ headers: { "X-RateLimit-Limit": "60" } })),
+  getClientIp: vi.fn(() => "127.0.0.1"),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(() => ({
+    allowed: true,
+    remaining: 59,
+    resetAt: Date.now() + 60000,
+  })),
+}));
+
+vi.mock("@/lib/workspace-auth", () => ({
+  requireWorkspace: vi.fn(),
+  authenticateWorkspace: vi.fn(),
+  extractApiKey: vi.fn(),
+}));
+
+vi.mock("@/lib/stream-token", () => ({
+  createStreamToken: vi.fn(() => "mock-token.mock-sig"),
+  verifyStreamToken: vi.fn(),
+}));
+
+import { prisma } from "@/lib/db";
+import {
+  authenticateWorkspace,
+  extractApiKey,
+} from "@/lib/workspace-auth";
+import { verifyStreamToken } from "@/lib/stream-token";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = prisma as any;
+const mockWorkspace = { id: "ws-1", name: "Test", slug: "test" };
+
+describe("POST /api/stream/token", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(extractApiKey).mockReturnValue(null);
+  });
+
+  it("returns token when authenticated via Bearer", async () => {
+    vi.mocked(authenticateWorkspace).mockResolvedValue(mockWorkspace);
+
+    const { POST } = await import("@/app/api/stream/token/route");
+    const req = new NextRequest("http://localhost/api/stream/token", {
+      method: "POST",
+      headers: { Authorization: "Bearer ws_token" },
+    });
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.token).toBe("mock-token.mock-sig");
+    expect(body.expiresIn).toBe(300);
+  });
+
+  it("returns token when authenticated via x-api-key (stream-only bridge)", async () => {
+    // First call: Bearer auth fails (no header)
+    // Second call: synthetic Bearer request with API key succeeds
+    vi.mocked(authenticateWorkspace)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(mockWorkspace);
+    vi.mocked(extractApiKey).mockReturnValue("ws_api_key_123");
+
+    const { POST } = await import("@/app/api/stream/token/route");
+    const req = new NextRequest("http://localhost/api/stream/token", {
+      method: "POST",
+      headers: { "x-api-key": "ws_api_key_123" },
+    });
+    const res = await POST(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.token).toBeDefined();
+    expect(body.expiresIn).toBe(300);
+
+    // authenticateWorkspace called twice: once for Bearer, once for API key
+    expect(authenticateWorkspace).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 401 without any auth", async () => {
+    vi.mocked(authenticateWorkspace).mockResolvedValue(null);
+
+    const { POST } = await import("@/app/api/stream/token/route");
+    const req = new NextRequest("http://localhost/api/stream/token", {
+      method: "POST",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toContain("Unauthorized");
+  });
+
+  it("returns 401 when x-api-key is invalid", async () => {
+    vi.mocked(authenticateWorkspace).mockResolvedValue(null);
+    vi.mocked(extractApiKey).mockReturnValue("ws_bad_key");
+
+    const { POST } = await import("@/app/api/stream/token/route");
+    const req = new NextRequest("http://localhost/api/stream/token", {
+      method: "POST",
+      headers: { "x-api-key": "ws_bad_key" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/stream", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 when token is missing", async () => {
+    const { GET } = await import("@/app/api/stream/route");
+    const req = new NextRequest("http://localhost/api/stream");
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Missing token query parameter");
+  });
+
+  it("returns 401 when token is invalid", async () => {
+    vi.mocked(verifyStreamToken).mockReturnValue({
+      valid: false,
+      error: "Invalid signature",
+    });
+
+    const { GET } = await import("@/app/api/stream/route");
+    const req = new NextRequest(
+      "http://localhost/api/stream?token=bad-token",
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid signature");
+  });
+
+  it("returns SSE stream with valid token", async () => {
+    vi.mocked(verifyStreamToken).mockReturnValue({
+      valid: true,
+      workspaceId: "ws-1",
+    });
+
+    mockPrisma.outboxEvent.findFirst.mockResolvedValue({ seq: 100 });
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/stream/route");
+    const controller = new AbortController();
+    const req = new NextRequest(
+      "http://localhost/api/stream?token=valid-token",
+      { signal: controller.signal },
+    );
+
+    const res = await GET(req);
+    expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+    expect(res.headers.get("Cache-Control")).toBe("no-cache, no-transform");
+
+    controller.abort();
+  });
+
+  it("tail cursor is scoped to visible events (public + workspace)", async () => {
+    vi.mocked(verifyStreamToken).mockReturnValue({
+      valid: true,
+      workspaceId: "ws-1",
+    });
+
+    mockPrisma.outboxEvent.findFirst.mockResolvedValue({ seq: 50 });
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/stream/route");
+    const controller = new AbortController();
+    const req = new NextRequest(
+      "http://localhost/api/stream?token=valid-token",
+      { signal: controller.signal },
+    );
+
+    await GET(req);
+
+    // findFirst must filter by visibility (public OR this workspace)
+    expect(mockPrisma.outboxEvent.findFirst).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { visibility: "public" },
+          { visibility: "workspace", workspaceId: "ws-1" },
+        ],
+      },
+      orderBy: { seq: "desc" },
+      select: { seq: true },
+    });
+
+    controller.abort();
+  });
+
+  it("channels filter applies to both tail cursor and poll query", async () => {
+    vi.mocked(verifyStreamToken).mockReturnValue({
+      valid: true,
+      workspaceId: "ws-1",
+    });
+
+    mockPrisma.outboxEvent.findFirst.mockResolvedValue({ seq: 10 });
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/stream/route");
+    const controller = new AbortController();
+    const req = new NextRequest(
+      "http://localhost/api/stream?token=valid-token&channels=anomaly,network",
+      { signal: controller.signal },
+    );
+
+    await GET(req);
+
+    // Tail cursor (findFirst) must include channel scope
+    expect(mockPrisma.outboxEvent.findFirst).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { visibility: "public" },
+          { visibility: "workspace", workspaceId: "ws-1" },
+        ],
+        channel: { in: ["anomaly", "network"] },
+      },
+      orderBy: { seq: "desc" },
+      select: { seq: true },
+    });
+
+    // Wait a tick for the first poll inside run()
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Poll query must also include channel scope
+    expect(mockPrisma.outboxEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          channel: { in: ["anomaly", "network"] },
+        }),
+      }),
+    );
+
+    controller.abort();
+  });
+});
+
+describe("GET /api/stream/public", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns SSE stream without authentication", async () => {
+    mockPrisma.outboxEvent.findFirst.mockResolvedValue({ seq: 50 });
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/stream/public/route");
+    const controller = new AbortController();
+    const req = new NextRequest("http://localhost/api/stream/public", {
+      signal: controller.signal,
+    });
+
+    const res = await GET(req);
+    expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+
+    controller.abort();
+  });
+
+  it("uses tail mode when no Last-Event-ID header", async () => {
+    mockPrisma.outboxEvent.findFirst.mockResolvedValue({ seq: 99 });
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/stream/public/route");
+    const controller = new AbortController();
+    const req = new NextRequest("http://localhost/api/stream/public", {
+      signal: controller.signal,
+    });
+
+    await GET(req);
+
+    expect(mockPrisma.outboxEvent.findFirst).toHaveBeenCalledWith({
+      where: { visibility: "public" },
+      orderBy: { seq: "desc" },
+      select: { seq: true },
+    });
+
+    controller.abort();
+  });
+
+  it("resumes from Last-Event-ID when provided", async () => {
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/stream/public/route");
+    const controller = new AbortController();
+    const req = new NextRequest("http://localhost/api/stream/public", {
+      headers: { "Last-Event-ID": "42" },
+      signal: controller.signal,
+    });
+
+    await GET(req);
+
+    // findFirst should NOT be called when Last-Event-ID is present
+    expect(mockPrisma.outboxEvent.findFirst).not.toHaveBeenCalled();
+
+    controller.abort();
+  });
+
+  it("channels filter applies to both tail cursor and poll query", async () => {
+    mockPrisma.outboxEvent.findFirst.mockResolvedValue({ seq: 5 });
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/stream/public/route");
+    const controller = new AbortController();
+    const req = new NextRequest(
+      "http://localhost/api/stream/public?channels=network",
+      { signal: controller.signal },
+    );
+
+    await GET(req);
+
+    // Tail cursor (findFirst) must include channel scope
+    expect(mockPrisma.outboxEvent.findFirst).toHaveBeenCalledWith({
+      where: {
+        visibility: "public",
+        channel: { in: ["network"] },
+      },
+      orderBy: { seq: "desc" },
+      select: { seq: true },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Poll query must also include channel scope
+    expect(mockPrisma.outboxEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          channel: { in: ["network"] },
+        }),
+      }),
+    );
+
+    controller.abort();
+  });
+});
+
+describe("SSE frame format and resume behavior", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("public stream emits correct id/event/data SSE frame", async () => {
+    mockPrisma.outboxEvent.findFirst.mockResolvedValue({ seq: 0 });
+
+    const mockEvent = {
+      id: "evt-1",
+      seq: 1,
+      channel: "anomaly",
+      type: "anomaly.created",
+      visibility: "public",
+      workspaceId: null,
+      payload: '{"anomalyType":"jailing"}',
+      createdAt: new Date(),
+    };
+    mockPrisma.outboxEvent.findMany
+      .mockResolvedValueOnce([mockEvent])
+      .mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/stream/public/route");
+    const controller = new AbortController();
+    const req = new NextRequest("http://localhost/api/stream/public", {
+      signal: controller.signal,
+    });
+
+    const res = await GET(req);
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+
+    let output = "";
+    for (let i = 0; i < 5; i++) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value, { stream: true });
+      if (output.includes("anomaly.created")) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    expect(output).toContain("id: 1\n");
+    expect(output).toContain("event: anomaly.created\n");
+    expect(output).toContain('data: {"anomalyType":"jailing"}\n');
+  });
+
+  it("authenticated stream emits correct SSE frame", async () => {
+    vi.mocked(verifyStreamToken).mockReturnValue({
+      valid: true,
+      workspaceId: "ws-1",
+    });
+
+    mockPrisma.outboxEvent.findFirst.mockResolvedValue({ seq: 0 });
+
+    const mockEvent = {
+      id: "evt-2",
+      seq: 5,
+      channel: "network",
+      type: "stats.updated",
+      visibility: "public",
+      workspaceId: null,
+      payload: '{"blockHeight":"100"}',
+      createdAt: new Date(),
+    };
+    mockPrisma.outboxEvent.findMany
+      .mockResolvedValueOnce([mockEvent])
+      .mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/stream/route");
+    const controller = new AbortController();
+    const req = new NextRequest(
+      "http://localhost/api/stream?token=valid-token",
+      { signal: controller.signal },
+    );
+
+    const res = await GET(req);
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+
+    let output = "";
+    for (let i = 0; i < 5; i++) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value, { stream: true });
+      if (output.includes("stats.updated")) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    expect(output).toContain("id: 5\n");
+    expect(output).toContain("event: stats.updated\n");
+    expect(output).toContain('data: {"blockHeight":"100"}\n');
+  });
+
+  it("public stream resumes from Last-Event-ID and polls from that seq", async () => {
+    const mockEvent = {
+      id: "evt-3",
+      seq: 43,
+      channel: "anomaly",
+      type: "anomaly.resolved",
+      visibility: "public",
+      workspaceId: null,
+      payload: '{"anomalyType":"jailing","resolvedCount":1}',
+      createdAt: new Date(),
+    };
+    mockPrisma.outboxEvent.findMany
+      .mockResolvedValueOnce([mockEvent])
+      .mockResolvedValue([]);
+
+    const { GET } = await import("@/app/api/stream/public/route");
+    const controller = new AbortController();
+    const req = new NextRequest("http://localhost/api/stream/public", {
+      headers: { "Last-Event-ID": "42" },
+      signal: controller.signal,
+    });
+
+    const res = await GET(req);
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+
+    let output = "";
+    for (let i = 0; i < 5; i++) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      output += decoder.decode(value, { stream: true });
+      if (output.includes("anomaly.resolved")) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    // Should NOT call findFirst (tail mode) when Last-Event-ID present
+    expect(mockPrisma.outboxEvent.findFirst).not.toHaveBeenCalled();
+
+    // Poll should use seq > 42
+    expect(mockPrisma.outboxEvent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          seq: { gt: 42 },
+        }),
+      }),
+    );
+
+    // Frame should contain the event
+    expect(output).toContain("id: 43\n");
+    expect(output).toContain("event: anomaly.resolved\n");
+  });
+});

--- a/tests/unit/indexer/cleanup.test.ts
+++ b/tests/unit/indexer/cleanup.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/lib/db", () => ({
     endpointScore: { deleteMany: vi.fn() },
     validatorScore: { deleteMany: vi.fn() },
     anomaly: { deleteMany: vi.fn() },
+    outboxEvent: { deleteMany: vi.fn() },
   },
 }));
 
@@ -31,6 +32,7 @@ describe("cleanupOldData", () => {
       { count: 10 },
       { count: 5 },
       { count: 3 },
+      { count: 7 },
     ]);
 
     const result = await cleanupOldData();
@@ -41,11 +43,13 @@ describe("cleanupOldData", () => {
     expect(result.deletedScores).toBe(10);
     expect(result.deletedValidatorScores).toBe(5);
     expect(result.deletedAnomalies).toBe(3);
+    expect(result.deletedOutboxEvents).toBe(7);
     expect(result.duration).toBeGreaterThanOrEqual(0);
   });
 
   it("handles empty tables", async () => {
     mockPrisma.$transaction.mockResolvedValue([
+      { count: 0 },
       { count: 0 },
       { count: 0 },
       { count: 0 },
@@ -59,6 +63,7 @@ describe("cleanupOldData", () => {
     expect(result.deletedSnapshots).toBe(0);
     expect(result.deletedHealthChecks).toBe(0);
     expect(result.deletedStats).toBe(0);
+    expect(result.deletedOutboxEvents).toBe(0);
   });
 
   it("throws IndexerError on failure", async () => {

--- a/tests/unit/indexer/stats.test.ts
+++ b/tests/unit/indexer/stats.test.ts
@@ -19,6 +19,11 @@ vi.mock("@/lib/republic", () => ({
   })),
 }));
 
+vi.mock("@/lib/events/publish", () => ({
+  publishEvent: vi.fn().mockResolvedValue(1),
+  publishEvents: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { aggregateStats } from "@/lib/indexer/stats";
 import { prisma } from "@/lib/db";
 import { getRepublicClient } from "@/lib/republic";

--- a/tests/unit/lib/intelligence/anomaly.test.ts
+++ b/tests/unit/lib/intelligence/anomaly.test.ts
@@ -9,8 +9,14 @@ vi.mock("@/lib/db", () => ({
       create: vi.fn(),
       updateMany: vi.fn(),
     },
+    outboxEvent: { create: vi.fn().mockResolvedValue({ seq: 1 }) },
     $queryRaw: vi.fn(),
   },
+}));
+
+vi.mock("@/lib/events/publish", () => ({
+  publishEvent: vi.fn().mockResolvedValue(1),
+  publishEvents: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { prisma } from "@/lib/db";

--- a/tests/unit/lib/publish.test.ts
+++ b/tests/unit/lib/publish.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    outboxEvent: {
+      create: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@/lib/db";
+import { publishEvent, publishEvents } from "@/lib/events/publish";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = prisma as any;
+
+describe("publishEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates outbox event with correct data", async () => {
+    mockPrisma.outboxEvent.create.mockResolvedValue({ seq: 42 });
+
+    const result = await publishEvent({
+      channel: "anomaly",
+      type: "anomaly.created",
+      payload: { anomalyType: "jailing", severity: "high" },
+    });
+
+    expect(result).toBe(42);
+    expect(mockPrisma.outboxEvent.create).toHaveBeenCalledWith({
+      data: {
+        channel: "anomaly",
+        type: "anomaly.created",
+        visibility: "public",
+        workspaceId: null,
+        payload: JSON.stringify({
+          anomalyType: "jailing",
+          severity: "high",
+        }),
+      },
+      select: { seq: true },
+    });
+  });
+
+  it("defaults visibility to public", async () => {
+    mockPrisma.outboxEvent.create.mockResolvedValue({ seq: 1 });
+
+    await publishEvent({
+      channel: "network",
+      type: "stats.updated",
+      payload: {},
+    });
+
+    expect(mockPrisma.outboxEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ visibility: "public" }),
+      }),
+    );
+  });
+
+  it("supports workspace visibility", async () => {
+    mockPrisma.outboxEvent.create.mockResolvedValue({ seq: 5 });
+
+    await publishEvent({
+      channel: "workspace",
+      type: "anomaly.created",
+      visibility: "workspace",
+      workspaceId: "ws-123",
+      payload: { test: true },
+    });
+
+    expect(mockPrisma.outboxEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          visibility: "workspace",
+          workspaceId: "ws-123",
+        }),
+      }),
+    );
+  });
+
+  it("returns null on DB error without throwing", async () => {
+    mockPrisma.outboxEvent.create.mockRejectedValue(
+      new Error("DB connection failed"),
+    );
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const result = await publishEvent({
+      channel: "anomaly",
+      type: "anomaly.created",
+      payload: {},
+    });
+
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});
+
+describe("publishEvents", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("publishes multiple events", async () => {
+    mockPrisma.outboxEvent.create
+      .mockResolvedValueOnce({ seq: 1 })
+      .mockResolvedValueOnce({ seq: 2 });
+
+    await publishEvents([
+      { channel: "anomaly", type: "anomaly.created", payload: { id: 1 } },
+      { channel: "anomaly", type: "validator.jailed", payload: { id: 2 } },
+    ]);
+
+    expect(mockPrisma.outboxEvent.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues on partial failure (Promise.allSettled)", async () => {
+    mockPrisma.outboxEvent.create
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockResolvedValueOnce({ seq: 2 });
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await publishEvents([
+      { channel: "anomaly", type: "anomaly.created", payload: {} },
+      { channel: "anomaly", type: "anomaly.resolved", payload: {} },
+    ]);
+
+    expect(mockPrisma.outboxEvent.create).toHaveBeenCalledTimes(2);
+    consoleSpy.mockRestore();
+  });
+});

--- a/tests/unit/lib/stream-token.test.ts
+++ b/tests/unit/lib/stream-token.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const TEST_SECRET = "a".repeat(64);
+
+describe("stream-token", () => {
+  const originalEnv = process.env.STREAM_TOKEN_SECRET;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.STREAM_TOKEN_SECRET = TEST_SECRET;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.STREAM_TOKEN_SECRET = originalEnv;
+    } else {
+      delete process.env.STREAM_TOKEN_SECRET;
+    }
+  });
+
+  it("createStreamToken returns dot-separated two-part string", async () => {
+    const { createStreamToken } = await import("@/lib/stream-token");
+    const token = createStreamToken("ws-123");
+    const parts = token.split(".");
+    expect(parts).toHaveLength(2);
+    expect(parts[0].length).toBeGreaterThan(0);
+    expect(parts[1].length).toBeGreaterThan(0);
+  });
+
+  it("create → verify roundtrip returns correct workspaceId", async () => {
+    const { createStreamToken, verifyStreamToken } = await import(
+      "@/lib/stream-token"
+    );
+    const token = createStreamToken("ws-456");
+    const result = verifyStreamToken(token);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.workspaceId).toBe("ws-456");
+    }
+  });
+
+  it("rejects expired token", async () => {
+    const { createStreamToken, verifyStreamToken } = await import(
+      "@/lib/stream-token"
+    );
+    const token = createStreamToken("ws-789", -1);
+    const result = verifyStreamToken(token);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toBe("Token expired");
+    }
+  });
+
+  it("rejects tampered signature", async () => {
+    const { createStreamToken, verifyStreamToken } = await import(
+      "@/lib/stream-token"
+    );
+    const token = createStreamToken("ws-123");
+    const [payload] = token.split(".");
+    const tampered = `${payload}.TAMPERED_SIGNATURE`;
+    const result = verifyStreamToken(tampered);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toBe("Invalid signature");
+    }
+  });
+
+  it("rejects tampered payload", async () => {
+    const { createStreamToken, verifyStreamToken } = await import(
+      "@/lib/stream-token"
+    );
+    const token = createStreamToken("ws-123");
+    const [, sig] = token.split(".");
+    const fakePayload = Buffer.from(
+      JSON.stringify({ wid: "ws-evil", exp: 9999999999 }),
+    )
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const result = verifyStreamToken(`${fakePayload}.${sig}`);
+    expect(result.valid).toBe(false);
+  });
+
+  it("rejects malformed token without dot", async () => {
+    const { verifyStreamToken } = await import("@/lib/stream-token");
+    const result = verifyStreamToken("nodothere");
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error).toBe("Malformed token");
+    }
+  });
+
+  it("rejects token signed with different secret", async () => {
+    const { createStreamToken } = await import("@/lib/stream-token");
+    const token = createStreamToken("ws-123");
+
+    // Change secret
+    process.env.STREAM_TOKEN_SECRET = "b".repeat(64);
+    vi.resetModules();
+    const { verifyStreamToken } = await import("@/lib/stream-token");
+    const result = verifyStreamToken(token);
+    expect(result.valid).toBe(false);
+  });
+
+  it("throws when STREAM_TOKEN_SECRET is missing", async () => {
+    delete process.env.STREAM_TOKEN_SECRET;
+    const { createStreamToken } = await import("@/lib/stream-token");
+    expect(() => createStreamToken("ws-123")).toThrow("STREAM_TOKEN_SECRET");
+  });
+
+  it("throws when STREAM_TOKEN_SECRET is too short", async () => {
+    process.env.STREAM_TOKEN_SECRET = "tooshort";
+    const { createStreamToken } = await import("@/lib/stream-token");
+    expect(() => createStreamToken("ws-123")).toThrow("STREAM_TOKEN_SECRET");
+  });
+});

--- a/tests/unit/lib/workspace-auth.test.ts
+++ b/tests/unit/lib/workspace-auth.test.ts
@@ -13,6 +13,7 @@ import { prisma } from "@/lib/db";
 import {
   hashToken,
   extractBearerToken,
+  extractApiKey,
   authenticateWorkspace,
   requireWorkspace,
 } from "@/lib/workspace-auth";
@@ -74,6 +75,34 @@ describe("extractBearerToken", () => {
   });
 });
 
+describe("extractApiKey", () => {
+  it("extracts key from x-api-key header", () => {
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { "x-api-key": "ws_my-api-key" },
+    });
+    expect(extractApiKey(req)).toBe("ws_my-api-key");
+  });
+
+  it("returns null when no x-api-key header", () => {
+    const req = new NextRequest("http://localhost/api/test");
+    expect(extractApiKey(req)).toBeNull();
+  });
+
+  it("returns null for empty x-api-key value", () => {
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { "x-api-key": "  " },
+    });
+    expect(extractApiKey(req)).toBeNull();
+  });
+
+  it("trims whitespace from key", () => {
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { "x-api-key": "  ws_my-key  " },
+    });
+    expect(extractApiKey(req)).toBe("ws_my-key");
+  });
+});
+
 describe("authenticateWorkspace", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -130,6 +159,16 @@ describe("authenticateWorkspace", () => {
 
     const result = await authenticateWorkspace(req);
     expect(result).toBeNull();
+  });
+
+  it("does not fall back to x-api-key (Bearer only)", async () => {
+    const req = new NextRequest("http://localhost/api/test", {
+      headers: { "x-api-key": TEST_TOKEN },
+    });
+
+    const result = await authenticateWorkspace(req);
+    expect(result).toBeNull();
+    expect(prisma.workspace.findFirst).not.toHaveBeenCalled();
   });
 
   it("queries with hashed token and isActive filter", async () => {


### PR DESCRIPTION
## Summary

- **Event publish layer**: fire-and-forget `publishEvent()` / `publishEvents()` writing to `OutboxEvent` table. DB errors are logged but never propagate to callers.
- **Anomaly event emission**: `createOrSkipAnomaly` and `resolveAnomalies` now emit 6 event types (`anomaly.created`, `anomaly.resolved`, `validator.jailed`, `validator.unjailed`, `endpoint.down`, `endpoint.recovered`).
- **Stats event emission**: `aggregateStats` emits `stats.updated` after each network stats snapshot.
- **Public SSE stream** (`GET /api/stream/public`): no auth, tail mode on first connect, `Last-Event-ID` resume, channel filtering via `?channels=`.
- **Authenticated SSE stream** (`GET /api/stream?token=xxx`): HMAC-SHA256 signed token with 5min TTL, workspace-scoped visibility filter, channel filtering.
- **Stream token endpoint** (`POST /api/stream/token`): workspace Bearer auth + `x-api-key` compatibility bridge (stream-only, not global). True API key model deferred to v1.3.1.
- **Single-flight polling**: `while/await/sleep` loop prevents overlapping polls and duplicate delivery.
- **Shared base filter**: tail cursor and poll query use the same `baseFilter` object — structurally impossible for visibility/channel scope to diverge.
- **OutboxEvent cleanup**: 24h retention added to existing cleanup transaction.
- **Client hook**: `useEventStream` with SWR `mutate` integration for dashboard revalidation.

## New files (10)

| File | Purpose |
|------|---------|
| `src/lib/events/event-types.ts` | Channel constants, anomaly→event type mappings |
| `src/lib/events/publish.ts` | Fire-and-forget outbox writer |
| `src/lib/stream-token.ts` | HMAC-SHA256 signed token create/verify |
| `src/app/api/stream/token/route.ts` | Token endpoint (Bearer + x-api-key bridge) |
| `src/app/api/stream/public/route.ts` | Public SSE stream |
| `src/app/api/stream/route.ts` | Authenticated SSE stream |
| `src/hooks/use-event-stream.ts` | Client EventSource hook |
| `tests/unit/lib/stream-token.test.ts` | 9 token tests |
| `tests/unit/lib/publish.test.ts` | 6 publish tests |
| `tests/unit/api/stream.test.ts` | 16 stream endpoint tests |

## Modified files (6)

| File | Change |
|------|--------|
| `src/lib/constants.ts` | `STREAM_DEFAULTS`, `OUTBOX_RETENTION` |
| `src/lib/intelligence/anomaly.ts` | Event emission on create/resolve |
| `src/lib/indexer/stats.ts` | `stats.updated` event emission |
| `src/lib/indexer/cleanup.ts` | OutboxEvent 24h retention |
| `src/lib/workspace-auth.ts` | `extractApiKey()` export (Bearer-only auth unchanged) |
| `.env.example` | `STREAM_TOKEN_SECRET` |

## Scope notes

- **x-api-key bridge**: Only `POST /api/stream/token` accepts `x-api-key` header as workspace token compatibility. `requireWorkspace` and all write endpoints remain Bearer-only. True API key auth (dedicated model, quota, scopes) is planned for v1.3.1.
- **Dispatch/retry**: Out of scope (1.1.4 PR B).
- **No new Prisma models**: `OutboxEvent` and `WebhookCursor` already exist from PR #19.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm test` — 357/357 passed (321 existing + 36 new)
- [x] `npm run build` — success
- [ ] Manual: connect to `/api/stream/public` with `curl`, trigger anomaly detection, verify SSE frames
- [ ] Manual: obtain stream token via `POST /api/stream/token`, connect to `/api/stream?token=xxx`
- [ ] Manual: verify `Last-Event-ID` resume after disconnect/reconnect