### PR TITLE
feat(webhooks): add dispatch worker, cron route, and retry handling

### DIFF
--- a/.github/workflows/cron-webhooks.yml
+++ b/.github/workflows/cron-webhooks.yml
@@ -1,0 +1,29 @@
+name: "Cron: Webhook Dispatch"
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: cron-webhooks
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    if: ${{ vars.CRONS_ENABLED == 'true' }}
+    steps:
+      - name: Trigger webhook dispatch
+        run: |
+          HTTP_CODE=$(curl -s -o /tmp/response.json -w "%{http_code}" \
+            -X POST "${{ secrets.APP_URL }}/api/cron/webhooks" \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            -H "Content-Type: application/json")
+          echo "HTTP Status: $HTTP_CODE"
+          cat /tmp/response.json || true
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::Cron webhook dispatch failed with HTTP $HTTP_CODE"
+            exit 1
+          fi

--- a/src/app/api/cron/webhooks/route.ts
+++ b/src/app/api/cron/webhooks/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateCronAuth } from "@/lib/cron-auth";
+import { withRateLimit } from "@/lib/api-helpers";
+import { dispatchWebhooks } from "@/lib/webhooks/dispatch";
+
+export async function POST(request: NextRequest) {
+  const authError = validateCronAuth(request);
+  if (authError) return authError;
+
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  try {
+    const result = await dispatchWebhooks();
+    return NextResponse.json({ success: true, ...result });
+  } catch (error) {
+    console.error("[Cron Webhooks]", error);
+    const message =
+      process.env.NODE_ENV === "production"
+        ? "Internal server error"
+        : error instanceof Error
+          ? error.message
+          : "Unknown error";
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -125,3 +125,18 @@ export const STREAM_DEFAULTS = {
 export const OUTBOX_RETENTION = {
   HOURS: 24,
 } as const;
+
+export const WEBHOOK_DISPATCH = {
+  BATCH_SIZE: 50,
+  RETRY_BATCH_SIZE: 20,
+  TIMEOUT_MS: 5_000,
+  MAX_ATTEMPTS: 5,
+  RETRY_DELAYS_S: [30, 120, 600, 3_600, 21_600],
+  BUDGET_MS: 45_000,
+  STALE_CLAIM_MS: 300_000,
+} as const;
+
+export const DELIVERY_RETENTION = {
+  SUCCESS_DAYS: 7,
+  FAILURE_DAYS: 30,
+} as const;

--- a/src/lib/indexer/cleanup.ts
+++ b/src/lib/indexer/cleanup.ts
@@ -1,5 +1,5 @@
 import { prisma } from "@/lib/db";
-import { RETENTION, OUTBOX_RETENTION } from "@/lib/constants";
+import { RETENTION, OUTBOX_RETENTION, DELIVERY_RETENTION } from "@/lib/constants";
 import { IndexerError } from "@/lib/errors";
 
 export async function cleanupOldData(): Promise<{
@@ -10,6 +10,7 @@ export async function cleanupOldData(): Promise<{
   deletedValidatorScores: number;
   deletedAnomalies: number;
   deletedOutboxEvents: number;
+  deletedDeliveries: number;
   duration: number;
 }> {
   const start = Date.now();
@@ -33,8 +34,10 @@ export async function cleanupOldData(): Promise<{
     const scoreCutoff = new Date(Date.now() - 7 * 86400000);
     const anomalyCutoff = new Date(Date.now() - 30 * 86400000);
     const outboxCutoff = new Date(Date.now() - OUTBOX_RETENTION.HOURS * 3600_000);
+    const deliverySuccessCutoff = new Date(Date.now() - DELIVERY_RETENTION.SUCCESS_DAYS * 86400_000);
+    const deliveryFailureCutoff = new Date(Date.now() - DELIVERY_RETENTION.FAILURE_DAYS * 86400_000);
 
-    const [snapshots, healthChecks, stats, scores, vScores, anomalies, outboxEvents] = await prisma.$transaction([
+    const [snapshots, healthChecks, stats, scores, vScores, anomalies, outboxEvents, deliveriesSuccess, deliveriesFailure] = await prisma.$transaction([
       prisma.validatorSnapshot.deleteMany({
         where: { timestamp: { lt: snapshotCutoff } },
       }),
@@ -56,6 +59,12 @@ export async function cleanupOldData(): Promise<{
       prisma.outboxEvent.deleteMany({
         where: { createdAt: { lt: outboxCutoff } },
       }),
+      prisma.webhookDelivery.deleteMany({
+        where: { success: true, createdAt: { lt: deliverySuccessCutoff } },
+      }),
+      prisma.webhookDelivery.deleteMany({
+        where: { success: false, nextRetryAt: null, createdAt: { lt: deliveryFailureCutoff } },
+      }),
     ]);
 
     return {
@@ -66,6 +75,7 @@ export async function cleanupOldData(): Promise<{
       deletedValidatorScores: vScores.count,
       deletedAnomalies: anomalies.count,
       deletedOutboxEvents: outboxEvents.count,
+      deletedDeliveries: deliveriesSuccess.count + deliveriesFailure.count,
       duration: Date.now() - start,
     };
   } catch (error) {

--- a/src/lib/webhooks/deliver.ts
+++ b/src/lib/webhooks/deliver.ts
@@ -1,0 +1,85 @@
+import { decryptSecret, signPayload } from "@/lib/webhook-crypto";
+import { assertUrlNotPrivate } from "@/lib/webhook-validation";
+import { WEBHOOK_DISPATCH } from "@/lib/constants";
+
+export interface DeliveryTarget {
+  webhookId: string;
+  url: string;
+  secretEncrypted: string;
+}
+
+export interface DeliveryPayload {
+  outboxEventId: string;
+  eventType: string;
+  payload: string;
+}
+
+export interface DeliveryResult {
+  success: boolean;
+  statusCode: number | null;
+  responseBody: string | null;
+  error?: string;
+}
+
+export async function deliverWebhook(
+  target: DeliveryTarget,
+  event: DeliveryPayload,
+): Promise<DeliveryResult> {
+  // 1. SSRF check (DNS resolution time)
+  try {
+    await assertUrlNotPrivate(target.url);
+  } catch {
+    return { success: false, statusCode: null, responseBody: null, error: "SSRF: blocked address" };
+  }
+
+  // 2. Decrypt secret + sign payload
+  let secret: string;
+  let signature: string;
+  try {
+    secret = decryptSecret(target.secretEncrypted);
+    signature = signPayload(secret, event.payload);
+  } catch (err) {
+    return {
+      success: false,
+      statusCode: null,
+      responseBody: null,
+      error: `Crypto: ${err instanceof Error ? err.message : "unknown"}`,
+    };
+  }
+
+  // 3. HTTP POST with timeout
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), WEBHOOK_DISPATCH.TIMEOUT_MS);
+
+  try {
+    const response = await fetch(target.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Signature": signature,
+        "X-Webhook-Event": event.eventType,
+        "X-Webhook-Delivery": event.outboxEventId,
+      },
+      body: event.payload,
+      signal: controller.signal,
+      redirect: "manual",
+    });
+
+    const responseBody = await response.text().catch(() => null);
+
+    return {
+      success: response.ok,
+      statusCode: response.status,
+      responseBody: responseBody?.slice(0, 1024) ?? null,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      statusCode: null,
+      responseBody: null,
+      error: err instanceof Error ? err.message : "Unknown error",
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/lib/webhooks/dispatch.ts
+++ b/src/lib/webhooks/dispatch.ts
@@ -1,0 +1,264 @@
+import { prisma } from "@/lib/db";
+import { WEBHOOK_DISPATCH } from "@/lib/constants";
+import { deliverWebhook } from "./deliver";
+
+export interface DispatchResult {
+  dispatched: number;
+  delivered: number;
+  retried: number;
+  failed: number;
+  duration: number;
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: string }).code === "P2002"
+  );
+}
+
+export async function dispatchWebhooks(): Promise<DispatchResult> {
+  const start = Date.now();
+  let dispatched = 0, delivered = 0, retried = 0, failed = 0;
+
+  const overBudget = () => Date.now() - start >= WEBHOOK_DISPATCH.BUDGET_MS;
+
+  // ═══════════════════════════════════════════
+  // PHASE A: Dispatch new events
+  // ═══════════════════════════════════════════
+
+  // A1. Read cursor (singleton, bootstrap: lastSeq=0)
+  const cursor = await prisma.webhookCursor.upsert({
+    where: { id: "singleton" },
+    create: { id: "singleton", lastSeq: 0 },
+    update: {},
+  });
+
+  // A2. Fetch events after last cursor
+  const events = await prisma.outboxEvent.findMany({
+    where: { seq: { gt: cursor.lastSeq } },
+    orderBy: { seq: "asc" },
+    take: WEBHOOK_DISPATCH.BATCH_SIZE,
+  });
+
+  // A3. For each event, find matching webhooks and deliver
+  let lastProcessedSeq = cursor.lastSeq;
+
+  for (const event of events) {
+    if (overBudget()) break;
+
+    const webhookFilter: Record<string, unknown> = {
+      isActive: true,
+      events: { has: event.type },
+    };
+    // Workspace-scoped event → only that workspace's webhooks
+    if (event.workspaceId) {
+      webhookFilter.workspaceId = event.workspaceId;
+    }
+
+    const webhooks = await prisma.webhook.findMany({
+      where: webhookFilter,
+      select: { id: true, url: true, secretEncrypted: true },
+    });
+
+    let budgetExhausted = false;
+
+    for (const webhook of webhooks) {
+      if (overBudget()) {
+        budgetExhausted = true;
+        break;
+      }
+
+      // Claim: create delivery row first (atomic dedup via unique constraint)
+      let deliveryId: string;
+      try {
+        const claimed = await prisma.webhookDelivery.create({
+          data: {
+            webhookId: webhook.id,
+            outboxEventId: event.id,
+            eventType: event.type,
+            payload: event.payload,
+            success: false,
+            attempts: 0,
+          },
+          select: { id: true },
+        });
+        deliveryId = claimed.id;
+      } catch (err) {
+        // Unique constraint violation → already claimed by another worker
+        if (isUniqueViolation(err)) continue;
+        throw err;
+      }
+
+      dispatched++;
+      try {
+        const result = await deliverWebhook(
+          { webhookId: webhook.id, url: webhook.url, secretEncrypted: webhook.secretEncrypted },
+          { outboxEventId: event.id, eventType: event.type, payload: event.payload },
+        );
+
+        if (result.success) {
+          delivered++;
+          await prisma.webhookDelivery.update({
+            where: { id: deliveryId },
+            data: {
+              success: true,
+              statusCode: result.statusCode,
+              responseBody: result.responseBody,
+              attempts: 1,
+              deliveredAt: new Date(),
+            },
+          });
+        } else {
+          failed++;
+          await prisma.webhookDelivery.update({
+            where: { id: deliveryId },
+            data: {
+              statusCode: result.statusCode,
+              responseBody: result.responseBody,
+              attempts: 1,
+              nextRetryAt: new Date(Date.now() + WEBHOOK_DISPATCH.RETRY_DELAYS_S[0] * 1000),
+            },
+          });
+        }
+      } catch {
+        // Claimed row must not stay stuck — make it retryable
+        failed++;
+        await prisma.webhookDelivery.update({
+          where: { id: deliveryId },
+          data: {
+            attempts: 1,
+            nextRetryAt: new Date(Date.now() + WEBHOOK_DISPATCH.RETRY_DELAYS_S[0] * 1000),
+          },
+        }).catch(() => {}); // Best-effort — don't let recovery crash the worker
+      }
+    }
+
+    // Only advance cursor past fully-processed events
+    if (!budgetExhausted) {
+      lastProcessedSeq = event.seq;
+    }
+
+    if (budgetExhausted) break;
+  }
+
+  // A4. Cursor compare-and-set (prevent race condition)
+  if (lastProcessedSeq > cursor.lastSeq) {
+    await prisma.$executeRaw`
+      UPDATE "WebhookCursor"
+      SET "lastSeq" = ${lastProcessedSeq}, "updatedAt" = NOW()
+      WHERE "id" = 'singleton' AND "lastSeq" < ${lastProcessedSeq}
+    `;
+  }
+
+  // ═══════════════════════════════════════════
+  // PHASE B: Process pending retries
+  // ═══════════════════════════════════════════
+
+  if (!overBudget()) {
+    const staleCutoff = new Date(Date.now() - WEBHOOK_DISPATCH.STALE_CLAIM_MS);
+
+    const pendingRetries = await prisma.webhookDelivery.findMany({
+      where: {
+        success: false,
+        OR: [
+          // Normal retries: failed deliveries with pending retry time
+          {
+            nextRetryAt: { lte: new Date() },
+            attempts: { lt: WEBHOOK_DISPATCH.MAX_ATTEMPTS },
+          },
+          // Stale claims: stuck rows from crashed workers (attempts=0, no nextRetryAt)
+          {
+            attempts: 0,
+            nextRetryAt: null,
+            createdAt: { lt: staleCutoff },
+          },
+        ],
+      },
+      include: {
+        webhook: {
+          select: { id: true, url: true, secretEncrypted: true, isActive: true },
+        },
+      },
+      take: WEBHOOK_DISPATCH.RETRY_BATCH_SIZE,
+      orderBy: { nextRetryAt: "asc" },
+    });
+
+    for (const delivery of pendingRetries) {
+      if (overBudget()) break;
+
+      // Skip retry if webhook deactivated, mark as dead letter
+      // Use Math.max to ensure stale claims (attempts=0) don't loop
+      if (!delivery.webhook.isActive) {
+        await prisma.webhookDelivery.update({
+          where: { id: delivery.id },
+          data: { nextRetryAt: null, attempts: Math.max(delivery.attempts, 1) },
+        });
+        continue;
+      }
+
+      retried++;
+      const newAttempts = delivery.attempts + 1;
+      const isDeadLetter = newAttempts >= WEBHOOK_DISPATCH.MAX_ATTEMPTS;
+
+      try {
+        const result = await deliverWebhook(
+          {
+            webhookId: delivery.webhook.id,
+            url: delivery.webhook.url,
+            secretEncrypted: delivery.webhook.secretEncrypted,
+          },
+          {
+            outboxEventId: delivery.outboxEventId,
+            eventType: delivery.eventType,
+            payload: delivery.payload,
+          },
+        );
+
+        if (result.success) {
+          delivered++;
+          await prisma.webhookDelivery.update({
+            where: { id: delivery.id },
+            data: {
+              success: true,
+              statusCode: result.statusCode,
+              responseBody: result.responseBody,
+              attempts: newAttempts,
+              deliveredAt: new Date(),
+              nextRetryAt: null,
+            },
+          });
+        } else {
+          failed++;
+          await prisma.webhookDelivery.update({
+            where: { id: delivery.id },
+            data: {
+              statusCode: result.statusCode,
+              responseBody: result.responseBody,
+              attempts: newAttempts,
+              nextRetryAt: isDeadLetter
+                ? null
+                : new Date(Date.now() + (WEBHOOK_DISPATCH.RETRY_DELAYS_S[newAttempts - 1] ?? 21_600) * 1000),
+            },
+          });
+        }
+      } catch {
+        // Unexpected error — bump attempts so row doesn't get stuck
+        failed++;
+        await prisma.webhookDelivery.update({
+          where: { id: delivery.id },
+          data: {
+            attempts: newAttempts,
+            nextRetryAt: isDeadLetter
+              ? null
+              : new Date(Date.now() + (WEBHOOK_DISPATCH.RETRY_DELAYS_S[newAttempts - 1] ?? 21_600) * 1000),
+          },
+        }).catch(() => {});
+      }
+    }
+  }
+
+  return { dispatched, delivered, retried, failed, duration: Date.now() - start };
+}

--- a/tests/unit/api/cron.test.ts
+++ b/tests/unit/api/cron.test.ts
@@ -15,6 +15,10 @@ vi.mock("@/lib/indexer", () => ({
   cleanupOldData: vi.fn(),
 }));
 
+vi.mock("@/lib/webhooks/dispatch", () => ({
+  dispatchWebhooks: vi.fn(),
+}));
+
 vi.mock("@/lib/intelligence", () => ({
   computeEndpointScores: vi.fn().mockResolvedValue({ scored: 3, duration: 100 }),
   computeValidatorScores: vi.fn().mockResolvedValue({ scored: 5, duration: 200 }),
@@ -24,6 +28,7 @@ vi.mock("@/lib/intelligence", () => ({
 import { validateCronAuth } from "@/lib/cron-auth";
 import { withRateLimit } from "@/lib/api-helpers";
 import { checkEndpoints, aggregateStats, cleanupOldData } from "@/lib/indexer";
+import { dispatchWebhooks } from "@/lib/webhooks/dispatch";
 
 function makeCronRequest(): NextRequest {
   return new NextRequest("http://localhost/api/cron/health", {
@@ -149,6 +154,51 @@ describe("Cron Routes", () => {
       );
 
       const { POST } = await import("@/app/api/cron/cleanup/route");
+      const res = await POST(makeCronRequest());
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body.success).toBe(false);
+    });
+  });
+
+  describe("POST /api/cron/webhooks", () => {
+    it("returns 401 when auth fails", async () => {
+      const { NextResponse } = await import("next/server");
+      vi.mocked(validateCronAuth).mockReturnValue(
+        NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+      );
+
+      const { POST } = await import("@/app/api/cron/webhooks/route");
+      const res = await POST(makeCronRequest());
+
+      expect(res.status).toBe(401);
+    });
+
+    it("returns success on dispatchWebhooks", async () => {
+      vi.mocked(dispatchWebhooks).mockResolvedValue({
+        dispatched: 5,
+        delivered: 4,
+        retried: 2,
+        failed: 1,
+        duration: 1200,
+      });
+
+      const { POST } = await import("@/app/api/cron/webhooks/route");
+      const res = await POST(makeCronRequest());
+      const body = await res.json();
+
+      expect(body.success).toBe(true);
+      expect(body.dispatched).toBe(5);
+      expect(body.delivered).toBe(4);
+    });
+
+    it("returns 500 on dispatch error", async () => {
+      vi.mocked(dispatchWebhooks).mockRejectedValue(
+        new Error("Dispatch failed"),
+      );
+
+      const { POST } = await import("@/app/api/cron/webhooks/route");
       const res = await POST(makeCronRequest());
       const body = await res.json();
 

--- a/tests/unit/indexer/cleanup.test.ts
+++ b/tests/unit/indexer/cleanup.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/db", () => ({
     validatorScore: { deleteMany: vi.fn() },
     anomaly: { deleteMany: vi.fn() },
     outboxEvent: { deleteMany: vi.fn() },
+    webhookDelivery: { deleteMany: vi.fn() },
   },
 }));
 
@@ -33,6 +34,8 @@ describe("cleanupOldData", () => {
       { count: 5 },
       { count: 3 },
       { count: 7 },
+      { count: 12 },
+      { count: 4 },
     ]);
 
     const result = await cleanupOldData();
@@ -44,11 +47,14 @@ describe("cleanupOldData", () => {
     expect(result.deletedValidatorScores).toBe(5);
     expect(result.deletedAnomalies).toBe(3);
     expect(result.deletedOutboxEvents).toBe(7);
+    expect(result.deletedDeliveries).toBe(16);
     expect(result.duration).toBeGreaterThanOrEqual(0);
   });
 
   it("handles empty tables", async () => {
     mockPrisma.$transaction.mockResolvedValue([
+      { count: 0 },
+      { count: 0 },
       { count: 0 },
       { count: 0 },
       { count: 0 },
@@ -64,6 +70,7 @@ describe("cleanupOldData", () => {
     expect(result.deletedHealthChecks).toBe(0);
     expect(result.deletedStats).toBe(0);
     expect(result.deletedOutboxEvents).toBe(0);
+    expect(result.deletedDeliveries).toBe(0);
   });
 
   it("throws IndexerError on failure", async () => {

--- a/tests/unit/lib/webhooks/dispatch.test.ts
+++ b/tests/unit/lib/webhooks/dispatch.test.ts
@@ -1,0 +1,760 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  prisma: {
+    webhookCursor: { upsert: vi.fn() },
+    outboxEvent: { findMany: vi.fn() },
+    webhook: { findMany: vi.fn() },
+    webhookDelivery: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    $executeRaw: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/webhook-crypto", () => ({
+  decryptSecret: vi.fn(() => "plain-secret"),
+  signPayload: vi.fn(() => "mock-signature"),
+}));
+
+vi.mock("@/lib/webhook-validation", () => ({
+  assertUrlNotPrivate: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { dispatchWebhooks } from "@/lib/webhooks/dispatch";
+import { prisma } from "@/lib/db";
+import { assertUrlNotPrivate } from "@/lib/webhook-validation";
+import { WEBHOOK_DISPATCH } from "@/lib/constants";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = prisma as any;
+const mockAssertUrl = assertUrlNotPrivate as ReturnType<typeof vi.fn>;
+
+function makeEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "evt-1",
+    seq: 1,
+    channel: "anomaly",
+    type: "anomaly.created",
+    visibility: "public",
+    workspaceId: null,
+    payload: '{"test":true}',
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeWebhook(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "wh-1",
+    url: "https://example.com/webhook",
+    secretEncrypted: "encrypted-secret",
+    ...overrides,
+  };
+}
+
+function mockFetchSuccess(status = 200, body = "OK") {
+  mockFetch.mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(body),
+  });
+}
+
+function mockFetchFailure(status = 500, body = "Internal Server Error") {
+  mockFetch.mockResolvedValue({
+    ok: false,
+    status,
+    text: () => Promise.resolve(body),
+  });
+}
+
+/** Setup Phase A: event + webhook + successful claim */
+function setupPhaseA(
+  event = makeEvent(),
+  webhook = makeWebhook(),
+) {
+  mockPrisma.outboxEvent.findMany.mockResolvedValue([event]);
+  mockPrisma.webhook.findMany.mockResolvedValue([webhook]);
+  mockPrisma.webhookDelivery.create.mockResolvedValue({ id: "del-claimed" });
+  mockPrisma.webhookDelivery.update.mockResolvedValue({});
+}
+
+describe("dispatchWebhooks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPrisma.webhookCursor.upsert.mockResolvedValue({ id: "singleton", lastSeq: 0 });
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([]);
+    mockPrisma.webhookDelivery.findMany.mockResolvedValue([]);
+    mockPrisma.$executeRaw.mockResolvedValue(1);
+    mockAssertUrl.mockResolvedValue(undefined);
+  });
+
+  // ═══════════════════════════════════════════
+  // PHASE A: New Event Dispatch
+  // ═══════════════════════════════════════════
+
+  it("bootstraps cursor with upsert (singleton)", async () => {
+    await dispatchWebhooks();
+
+    expect(mockPrisma.webhookCursor.upsert).toHaveBeenCalledWith({
+      where: { id: "singleton" },
+      create: { id: "singleton", lastSeq: 0 },
+      update: {},
+    });
+  });
+
+  it("returns zeros when no events exist", async () => {
+    const result = await dispatchWebhooks();
+
+    expect(result.dispatched).toBe(0);
+    expect(result.delivered).toBe(0);
+    expect(result.retried).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it("claims delivery then updates on success (atomic dedup)", async () => {
+    setupPhaseA();
+    mockFetchSuccess();
+
+    const result = await dispatchWebhooks();
+
+    expect(result.dispatched).toBe(1);
+    expect(result.delivered).toBe(1);
+    // Step 1: claim row (attempts=0, success=false)
+    expect(mockPrisma.webhookDelivery.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        webhookId: "wh-1",
+        outboxEventId: "evt-1",
+        success: false,
+        attempts: 0,
+      }),
+      select: { id: true },
+    });
+    // Step 2: update with result
+    expect(mockPrisma.webhookDelivery.update).toHaveBeenCalledWith({
+      where: { id: "del-claimed" },
+      data: expect.objectContaining({
+        success: true,
+        statusCode: 200,
+        attempts: 1,
+        deliveredAt: expect.any(Date),
+      }),
+    });
+  });
+
+  it("dispatches single event to multiple webhooks", async () => {
+    const event = makeEvent();
+    const wh1 = makeWebhook({ id: "wh-1" });
+    const wh2 = makeWebhook({ id: "wh-2", url: "https://example2.com/webhook" });
+
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([event]);
+    mockPrisma.webhook.findMany.mockResolvedValue([wh1, wh2]);
+    mockPrisma.webhookDelivery.create.mockResolvedValue({ id: "del-claimed" });
+    mockPrisma.webhookDelivery.update.mockResolvedValue({});
+    mockFetchSuccess();
+
+    const result = await dispatchWebhooks();
+
+    expect(result.dispatched).toBe(2);
+    expect(result.delivered).toBe(2);
+    expect(mockPrisma.webhookDelivery.create).toHaveBeenCalledTimes(2);
+  });
+
+  it("dispatches multiple events and advances cursor to last seq", async () => {
+    const events = [
+      makeEvent({ id: "evt-1", seq: 5 }),
+      makeEvent({ id: "evt-2", seq: 6 }),
+      makeEvent({ id: "evt-3", seq: 7 }),
+    ];
+    mockPrisma.outboxEvent.findMany.mockResolvedValue(events);
+    mockPrisma.webhook.findMany.mockResolvedValue([makeWebhook()]);
+    mockPrisma.webhookDelivery.create.mockResolvedValue({ id: "del-claimed" });
+    mockPrisma.webhookDelivery.update.mockResolvedValue({});
+    mockFetchSuccess();
+
+    const result = await dispatchWebhooks();
+
+    expect(result.dispatched).toBe(3);
+    expect(mockPrisma.$executeRaw).toHaveBeenCalled();
+  });
+
+  it("skips duplicate delivery via unique constraint violation", async () => {
+    const event = makeEvent();
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([event]);
+    mockPrisma.webhook.findMany.mockResolvedValue([makeWebhook()]);
+    // Simulate Prisma P2002 unique constraint violation
+    const uniqueError = Object.assign(new Error("Unique constraint"), { code: "P2002" });
+    mockPrisma.webhookDelivery.create.mockRejectedValue(uniqueError);
+
+    const result = await dispatchWebhooks();
+
+    expect(result.dispatched).toBe(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockPrisma.webhookDelivery.update).not.toHaveBeenCalled();
+  });
+
+  it("rethrows non-unique-constraint errors from claim", async () => {
+    const event = makeEvent();
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([event]);
+    mockPrisma.webhook.findMany.mockResolvedValue([makeWebhook()]);
+    mockPrisma.webhookDelivery.create.mockRejectedValue(new Error("DB connection lost"));
+
+    await expect(dispatchWebhooks()).rejects.toThrow("DB connection lost");
+  });
+
+  it("recovers claimed row on unexpected post-claim error", async () => {
+    const event = makeEvent();
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([event]);
+    mockPrisma.webhook.findMany.mockResolvedValue([makeWebhook()]);
+    mockPrisma.webhookDelivery.create.mockResolvedValue({ id: "del-claimed" });
+    // deliverWebhook itself won't throw (crypto errors are caught in deliver.ts)
+    // but the update after it can throw
+    mockPrisma.webhookDelivery.update
+      .mockRejectedValueOnce(new Error("DB write failed")) // result update fails
+      .mockResolvedValue({}); // recovery update succeeds
+
+    mockFetchSuccess();
+
+    const result = await dispatchWebhooks();
+
+    // Should have counted as failed, not thrown
+    expect(result.failed).toBe(1);
+    // Recovery update should have been called with nextRetryAt
+    expect(mockPrisma.webhookDelivery.update).toHaveBeenCalledWith({
+      where: { id: "del-claimed" },
+      data: expect.objectContaining({
+        attempts: 1,
+        nextRetryAt: expect.any(Date),
+      }),
+    });
+  });
+
+  it("filters webhooks by workspace for workspace-scoped events", async () => {
+    const event = makeEvent({ workspaceId: "ws-1" });
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([event]);
+    mockPrisma.webhook.findMany.mockResolvedValue([]);
+
+    await dispatchWebhooks();
+
+    expect(mockPrisma.webhook.findMany).toHaveBeenCalledWith({
+      where: {
+        isActive: true,
+        events: { has: "anomaly.created" },
+        workspaceId: "ws-1",
+      },
+      select: { id: true, url: true, secretEncrypted: true },
+    });
+  });
+
+  it("does not filter by workspace for public events", async () => {
+    const event = makeEvent({ workspaceId: null });
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([event]);
+    mockPrisma.webhook.findMany.mockResolvedValue([]);
+
+    await dispatchWebhooks();
+
+    expect(mockPrisma.webhook.findMany).toHaveBeenCalledWith({
+      where: {
+        isActive: true,
+        events: { has: "anomaly.created" },
+      },
+      select: { id: true, url: true, secretEncrypted: true },
+    });
+  });
+
+  it("skips webhooks that don't match event type (via Prisma filter)", async () => {
+    const event = makeEvent({ type: "validator.jailed" });
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([event]);
+    mockPrisma.webhook.findMany.mockResolvedValue([]);
+
+    const result = await dispatchWebhooks();
+
+    expect(result.dispatched).toBe(0);
+    expect(mockPrisma.webhook.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          events: { has: "validator.jailed" },
+        }),
+      }),
+    );
+  });
+
+  it("records successful delivery with deliveredAt", async () => {
+    setupPhaseA();
+    mockFetchSuccess(200, "received");
+
+    await dispatchWebhooks();
+
+    expect(mockPrisma.webhookDelivery.update).toHaveBeenCalledWith({
+      where: { id: "del-claimed" },
+      data: expect.objectContaining({
+        success: true,
+        statusCode: 200,
+        responseBody: "received",
+        attempts: 1,
+        deliveredAt: expect.any(Date),
+      }),
+    });
+  });
+
+  it("records failed delivery with nextRetryAt", async () => {
+    setupPhaseA();
+    mockFetchFailure(500, "error");
+
+    const result = await dispatchWebhooks();
+
+    expect(result.failed).toBe(1);
+    expect(mockPrisma.webhookDelivery.update).toHaveBeenCalledWith({
+      where: { id: "del-claimed" },
+      data: expect.objectContaining({
+        statusCode: 500,
+        attempts: 1,
+        nextRetryAt: expect.any(Date),
+      }),
+    });
+  });
+
+  it("handles SSRF blocked address", async () => {
+    setupPhaseA();
+    mockAssertUrl.mockRejectedValue(new Error("blocked"));
+
+    const result = await dispatchWebhooks();
+
+    expect(result.failed).toBe(1);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockPrisma.webhookDelivery.update).toHaveBeenCalledWith({
+      where: { id: "del-claimed" },
+      data: expect.objectContaining({
+        statusCode: null,
+        responseBody: null,
+        attempts: 1,
+      }),
+    });
+  });
+
+  it("does not advance cursor when no events", async () => {
+    mockPrisma.outboxEvent.findMany.mockResolvedValue([]);
+
+    await dispatchWebhooks();
+
+    expect(mockPrisma.$executeRaw).not.toHaveBeenCalled();
+  });
+
+  it("only advances cursor past fully-processed events on budget exhaustion", async () => {
+    // Simulate budget exhaustion after first event by mocking Date.now
+    const realNow = Date.now;
+    let callCount = 0;
+    const baseTime = realNow();
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      callCount++;
+      // First few calls: normal time. After event 1 is processed, jump past budget.
+      if (callCount > 8) return baseTime + WEBHOOK_DISPATCH.BUDGET_MS + 1;
+      return baseTime;
+    });
+
+    const events = [
+      makeEvent({ id: "evt-1", seq: 10 }),
+      makeEvent({ id: "evt-2", seq: 11 }),
+    ];
+    mockPrisma.outboxEvent.findMany.mockResolvedValue(events);
+    mockPrisma.webhook.findMany.mockResolvedValue([makeWebhook()]);
+    mockPrisma.webhookDelivery.create.mockResolvedValue({ id: "del-claimed" });
+    mockPrisma.webhookDelivery.update.mockResolvedValue({});
+    mockFetchSuccess();
+
+    const result = await dispatchWebhooks();
+
+    // Should have processed at least 1 event but not necessarily both
+    expect(result.dispatched).toBeGreaterThanOrEqual(1);
+    // Cursor should have been advanced (at least first event processed)
+    expect(mockPrisma.$executeRaw).toHaveBeenCalled();
+
+    vi.spyOn(Date, "now").mockRestore();
+  });
+
+  // ═══════════════════════════════════════════
+  // PHASE B: Retry
+  // ═══════════════════════════════════════════
+
+  it("queries for both pending retries and stale claims", async () => {
+    mockPrisma.webhookDelivery.findMany.mockResolvedValue([]);
+
+    await dispatchWebhooks();
+
+    expect(mockPrisma.webhookDelivery.findMany).toHaveBeenCalledWith({
+      where: {
+        success: false,
+        OR: [
+          {
+            nextRetryAt: { lte: expect.any(Date) },
+            attempts: { lt: WEBHOOK_DISPATCH.MAX_ATTEMPTS },
+          },
+          {
+            attempts: 0,
+            nextRetryAt: null,
+            createdAt: { lt: expect.any(Date) },
+          },
+        ],
+      },
+      include: {
+        webhook: {
+          select: { id: true, url: true, secretEncrypted: true, isActive: true },
+        },
+      },
+      take: WEBHOOK_DISPATCH.RETRY_BATCH_SIZE,
+      orderBy: { nextRetryAt: "asc" },
+    });
+  });
+
+  it("retries successfully and updates delivery", async () => {
+    const pendingDelivery = {
+      id: "del-1",
+      webhookId: "wh-1",
+      outboxEventId: "evt-1",
+      eventType: "anomaly.created",
+      payload: '{"test":true}',
+      attempts: 1,
+      webhook: {
+        id: "wh-1",
+        url: "https://example.com/webhook",
+        secretEncrypted: "encrypted-secret",
+        isActive: true,
+      },
+    };
+    mockPrisma.webhookDelivery.findMany.mockResolvedValue([pendingDelivery]);
+    mockPrisma.webhookDelivery.update.mockResolvedValue({});
+    mockFetchSuccess(200, "ok");
+
+    const result = await dispatchWebhooks();
+
+    expect(result.retried).toBe(1);
+    expect(result.delivered).toBe(1);
+    expect(mockPrisma.webhookDelivery.update).toHaveBeenCalledWith({
+      where: { id: "del-1" },
+      data: expect.objectContaining({
+        success: true,
+        attempts: 2,
+        deliveredAt: expect.any(Date),
+        nextRetryAt: null,
+      }),
+    });
+  });
+
+  it("retries failed and updates nextRetryAt for next attempt", async () => {
+    const pendingDelivery = {
+      id: "del-1",
+      webhookId: "wh-1",
+      outboxEventId: "evt-1",
+      eventType: "anomaly.created",
+      payload: '{"test":true}',
+      attempts: 2,
+      webhook: {
+        id: "wh-1",
+        url: "https://example.com/webhook",
+        secretEncrypted: "encrypted-secret",
+        isActive: true,
+      },
+    };
+    mockPrisma.webhookDelivery.findMany.mockResolvedValue([pendingDelivery]);
+    mockPrisma.webhookDelivery.update.mockResolvedValue({});
+    mockFetchFailure(502, "Bad Gateway");
+
+    const result = await dispatchWebhooks();
+
+    expect(result.retried).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(mockPrisma.webhookDelivery.update).toHaveBeenCalledWith({
+      where: { id: "del-1" },
+      data: expect.objectContaining({
+        attempts: 3,
+        nextRetryAt: expect.any(Date),
+      }),
+    });
+  });
+
+  it("marks as dead letter when max attempts reached", async () => {
+    const pendingDelivery = {
+      id: "del-1",
+      webhookId: "wh-1",
+      outboxEventId: "evt-1",
+      eventType: "anomaly.created",
+      payload: '{"test":true}',
+      attempts: 4, // Next will be 5 = MAX_ATTEMPTS
+      webhook: {
+        id: "wh-1",
+        url: "https://example.com/webhook",
+        secretEncrypted: "encrypted-secret",
+        isActive: true,
+      },
+    };
+    mockPrisma.webhookDelivery.findMany.mockResolvedValue([pendingDelivery]);
+    mockPrisma.webhookDelivery.update.mockResolvedValue({});
+    mockFetchFailure(500, "error");
+
+    const result = await dispatchWebhooks();
+
+    expect(result.failed).toBe(1);
+    expect(mockPrisma.webhookDelivery.update).toHaveBeenCalledWith({
+      where: { id: "del-1" },
+      data: expect.objectContaining({
+        attempts: 5,
+        nextRetryAt: null, // dead letter
+      }),
+    });
+  });
+
+  it("skips retry for deactivated webhook and marks dead letter", async () => {
+    const pendingDelivery = {
+      id: "del-1",
+      webhookId: "wh-1",
+      outboxEventId: "evt-1",
+      eventType: "anomaly.created",
+      payload: '{"test":true}',
+      attempts: 1,
+      webhook: {
+        id: "wh-1",
+        url: "https://example.com/webhook",
+        secretEncrypted: "encrypted-secret",
+        isActive: false,
+      },
+    };
+    mockPrisma.webhookDelivery.findMany.mockResolvedValue([pendingDelivery]);
+    mockPrisma.webhookDelivery.update.mockResolvedValue({});
+
+    const result = await dispatchWebhooks();
+
+    expect(result.retried).toBe(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockPrisma.webhookDelivery.update).toHaveBeenCalledWith({
+      where: { id: "del-1" },
+      data: { nextRetryAt: null, attempts: 1 },
+    });
+  });
+
+  it("recovers retry row on unexpected error during retry phase", async () => {
+    const pendingDelivery = {
+      id: "del-1",
+      webhookId: "wh-1",
+      outboxEventId: "evt-1",
+      eventType: "anomaly.created",
+      payload: '{"test":true}',
+      attempts: 2,
+      webhook: {
+        id: "wh-1",
+        url: "https://example.com/webhook",
+        secretEncrypted: "encrypted-secret",
+        isActive: true,
+      },
+    };
+    mockPrisma.webhookDelivery.findMany.mockResolvedValue([pendingDelivery]);
+    // First update (result) throws, second update (recovery) succeeds
+    mockPrisma.webhookDelivery.update
+      .mockRejectedValueOnce(new Error("DB write failed"))
+      .mockResolvedValue({});
+    mockFetchSuccess();
+
+    const result = await dispatchWebhooks();
+
+    // Should count as failed, not crash the worker
+    expect(result.failed).toBe(1);
+    // Recovery update bumps attempts and sets nextRetryAt
+    expect(mockPrisma.webhookDelivery.update).toHaveBeenCalledWith({
+      where: { id: "del-1" },
+      data: expect.objectContaining({
+        attempts: 3,
+        nextRetryAt: expect.any(Date),
+      }),
+    });
+  });
+
+  it("uses correct exponential backoff delays (no off-by-one)", async () => {
+    // attempts=1 → newAttempts=2 → RETRY_DELAYS_S[2-1] = RETRY_DELAYS_S[1] = 120s
+    const pendingDelivery = {
+      id: "del-1",
+      webhookId: "wh-1",
+      outboxEventId: "evt-1",
+      eventType: "anomaly.created",
+      payload: '{"test":true}',
+      attempts: 1,
+      webhook: {
+        id: "wh-1",
+        url: "https://example.com/webhook",
+        secretEncrypted: "encrypted-secret",
+        isActive: true,
+      },
+    };
+    mockPrisma.webhookDelivery.findMany.mockResolvedValue([pendingDelivery]);
+    mockPrisma.webhookDelivery.update.mockResolvedValue({});
+    mockFetchFailure();
+
+    const before = Date.now();
+    await dispatchWebhooks();
+
+    const updateCall = mockPrisma.webhookDelivery.update.mock.calls[0][0];
+    const nextRetry = updateCall.data.nextRetryAt.getTime();
+    // newAttempts = 2, RETRY_DELAYS_S[2-1] = RETRY_DELAYS_S[1] = 120s
+    const expectedDelay = WEBHOOK_DISPATCH.RETRY_DELAYS_S[1] * 1000;
+    expect(nextRetry).toBeGreaterThanOrEqual(before + expectedDelay - 100);
+    expect(nextRetry).toBeLessThanOrEqual(before + expectedDelay + 1000);
+  });
+
+  it("walks through all backoff delays in sequence", async () => {
+    // Verify each attempt uses the correct delay index
+    for (let currentAttempts = 1; currentAttempts < WEBHOOK_DISPATCH.MAX_ATTEMPTS; currentAttempts++) {
+      vi.clearAllMocks();
+      mockPrisma.webhookCursor.upsert.mockResolvedValue({ id: "singleton", lastSeq: 0 });
+      mockPrisma.outboxEvent.findMany.mockResolvedValue([]);
+      mockPrisma.$executeRaw.mockResolvedValue(1);
+      mockAssertUrl.mockResolvedValue(undefined);
+
+      const pendingDelivery = {
+        id: `del-${currentAttempts}`,
+        webhookId: "wh-1",
+        outboxEventId: "evt-1",
+        eventType: "anomaly.created",
+        payload: '{"test":true}',
+        attempts: currentAttempts,
+        webhook: {
+          id: "wh-1",
+          url: "https://example.com/webhook",
+          secretEncrypted: "encrypted-secret",
+          isActive: true,
+        },
+      };
+      mockPrisma.webhookDelivery.findMany.mockResolvedValue([pendingDelivery]);
+      mockPrisma.webhookDelivery.update.mockResolvedValue({});
+      mockFetchFailure();
+
+      const before = Date.now();
+      await dispatchWebhooks();
+
+      const newAttempts = currentAttempts + 1;
+      if (newAttempts >= WEBHOOK_DISPATCH.MAX_ATTEMPTS) {
+        // Dead letter
+        const updateCall = mockPrisma.webhookDelivery.update.mock.calls[0][0];
+        expect(updateCall.data.nextRetryAt).toBeNull();
+      } else {
+        const updateCall = mockPrisma.webhookDelivery.update.mock.calls[0][0];
+        const nextRetry = updateCall.data.nextRetryAt.getTime();
+        const expectedDelay = WEBHOOK_DISPATCH.RETRY_DELAYS_S[newAttempts - 1] * 1000;
+        expect(nextRetry).toBeGreaterThanOrEqual(before + expectedDelay - 100);
+        expect(nextRetry).toBeLessThanOrEqual(before + expectedDelay + 1000);
+      }
+    }
+  });
+
+  // ═══════════════════════════════════════════
+  // Integration: return value & edge cases
+  // ═══════════════════════════════════════════
+
+  it("returns correct DispatchResult structure", async () => {
+    const result = await dispatchWebhooks();
+
+    expect(result).toEqual({
+      dispatched: expect.any(Number),
+      delivered: expect.any(Number),
+      retried: expect.any(Number),
+      failed: expect.any(Number),
+      duration: expect.any(Number),
+    });
+  });
+
+  it("truncates response body to 1024 bytes", async () => {
+    setupPhaseA();
+    const longBody = "x".repeat(2000);
+    mockFetchSuccess(200, longBody);
+
+    await dispatchWebhooks();
+
+    const updateCall = mockPrisma.webhookDelivery.update.mock.calls[0][0];
+    expect(updateCall.data.responseBody.length).toBe(1024);
+  });
+
+  // ═══════════════════════════════════════════
+  // Stale-claim recovery
+  // ═══════════════════════════════════════════
+
+  it("does not crash when both result and recovery updates fail", async () => {
+    setupPhaseA();
+    mockFetchSuccess();
+    // All updates fail — both result update and recovery update
+    mockPrisma.webhookDelivery.update.mockRejectedValue(new Error("DB down"));
+
+    // Worker should NOT throw — catch(() => {}) absorbs the error
+    const result = await dispatchWebhooks();
+
+    expect(result.failed).toBe(1);
+  });
+
+  it("picks up stale claims (stuck rows) in retry phase", async () => {
+    const staleDelivery = {
+      id: "del-stale",
+      webhookId: "wh-1",
+      outboxEventId: "evt-old",
+      eventType: "anomaly.created",
+      payload: '{"test":true}',
+      attempts: 0,
+      nextRetryAt: null,
+      createdAt: new Date(Date.now() - 600_000), // 10 min ago — past stale threshold
+      webhook: {
+        id: "wh-1",
+        url: "https://example.com/webhook",
+        secretEncrypted: "encrypted-secret",
+        isActive: true,
+      },
+    };
+    mockPrisma.webhookDelivery.findMany.mockResolvedValue([staleDelivery]);
+    mockPrisma.webhookDelivery.update.mockResolvedValue({});
+    mockFetchSuccess();
+
+    const result = await dispatchWebhooks();
+
+    expect(result.retried).toBe(1);
+    expect(result.delivered).toBe(1);
+    expect(mockPrisma.webhookDelivery.update).toHaveBeenCalledWith({
+      where: { id: "del-stale" },
+      data: expect.objectContaining({
+        success: true,
+        attempts: 1,
+        deliveredAt: expect.any(Date),
+        nextRetryAt: null,
+      }),
+    });
+  });
+
+  it("marks stale claim as dead letter when webhook is deactivated", async () => {
+    const staleDelivery = {
+      id: "del-stale",
+      webhookId: "wh-1",
+      outboxEventId: "evt-old",
+      eventType: "anomaly.created",
+      payload: '{"test":true}',
+      attempts: 0,
+      nextRetryAt: null,
+      createdAt: new Date(Date.now() - 600_000),
+      webhook: {
+        id: "wh-1",
+        url: "https://example.com/webhook",
+        secretEncrypted: "encrypted-secret",
+        isActive: false,
+      },
+    };
+    mockPrisma.webhookDelivery.findMany.mockResolvedValue([staleDelivery]);
+    mockPrisma.webhookDelivery.update.mockResolvedValue({});
+
+    await dispatchWebhooks();
+
+    // Bumps attempts to 1 so it won't loop as stale claim again
+    expect(mockPrisma.webhookDelivery.update).toHaveBeenCalledWith({
+      where: { id: "del-stale" },
+      data: { nextRetryAt: null, attempts: 1 },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Durable webhook dispatch worker**: OutboxEvent'ler cursor-based batch processing ile webhook'lara teslim ediliyor
- **Atomic claim-first dedup**: Delivery row HTTP call'dan once olusturuluyor, P2002 unique violation ile race condition onleniyor
- **Exponential backoff retry**: 30s → 120s → 600s → 3600s → dead letter (5 deneme)
- **Stale-claim recovery**: Crash/error sonrasi stuck kalan row'lar (attempts=0, nextRetryAt=null) 5dk sonra retry phase tarafindan otomatik toparlanir — kalici delivery kaybi riski kapatildi
- **Wall-clock budget (45s)**: Dispatch GH Actions cron timeout'undan (60s) once durur, cursor sadece tam islenen event'lere kadar ilerler
- **Delivery cleanup**: 7 gun basarili, 30 gun basarisiz retention (cleanup transaction'a eklendi)
- **Cron endpoint + workflow**: POST /api/cron/webhooks, her 5dk calisir

### Kapsam notu

- Webhook CRUD, crypto, validation ve SSRF korumasi ayri PR'da tamamlandi (#19). Bu PR sadece dispatch/retry mekanizmasini kapsiyor.
- x-api-key / workspace auth bu PR'da yok; 1.3.1 gercek ApiKey modeline kadar ayri kaliyor.

### Yeni dosyalar

| Dosya | Amac |
|-------|------|
| `src/lib/webhooks/deliver.ts` | Tekil delivery: SSRF → decrypt → sign → fetch |
| `src/lib/webhooks/dispatch.ts` | Core dispatch: cursor → match → claim → deliver → retry |
| `src/app/api/cron/webhooks/route.ts` | Cron endpoint (auth + rate limit) |
| `tests/unit/lib/webhooks/dispatch.test.ts` | 29 unit test |
| `.github/workflows/cron-webhooks.yml` | GitHub Actions cron (5dk) |

### Degisen dosyalar

| Dosya | Degisiklik |
|-------|-----------|
| `src/lib/constants.ts` | WEBHOOK_DISPATCH + DELIVERY_RETENTION sabitleri |
| `src/lib/indexer/cleanup.ts` | WebhookDelivery retention eklendi |
| `tests/unit/api/cron.test.ts` | Cron route testleri (auth, success, error) |
| `tests/unit/indexer/cleanup.test.ts` | Delivery cleanup assertion'lari |

## Test plan

- [x] `npx tsc --noEmit` — type check temiz
- [x] `npm run lint` — ESLint temiz
- [x] `npm test` — 389/389 passed
- [x] `npm run build` — Next.js build basarili
- [ ] Deploy sonrasi: `CRONS_ENABLED=true` ile cron workflow'un tetiklendigini dogrula
- [ ] Test webhook endpoint'ine event publish edip delivery log'u kontrol et