### PR TITLE
fix(build): add prisma migrate deploy to build pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Chain Intelligence Platform for Republic AI",
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "prisma generate && next build",
+    "build": "prisma migrate deploy && prisma generate && next build",
     "postinstall": "prisma generate",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
## Summary
- Adds `prisma migrate deploy` to the build script before `prisma generate && next build`
- Ensures pending database migrations are automatically applied on every Vercel deployment
- Prevents runtime 500 errors caused by missing tables after schema changes

## Root Cause
The `Cron: Webhook Dispatch` workflow was failing with HTTP 500 because 2 migrations (`add_workspace_model`, `add_webhook_models`) were never applied to the production database. The build script only ran `prisma generate` (client codegen) but not `prisma migrate deploy`.

## Test plan
- [x] 389/389 unit tests passing
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Migrations manually applied and webhook dispatch confirmed working (HTTP 200)