### PR TITLE
fix(ci): separate migration deploy from CI build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Chain Intelligence Platform for Republic AI",
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "prisma migrate deploy && prisma generate && next build",
+    "build": "prisma generate && next build",
     "postinstall": "prisma generate",
     "start": "next start",
     "lint": "eslint",

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "buildCommand": "prisma migrate deploy && prisma generate && next build"
+}


### PR DESCRIPTION
## Summary
- Reverts `prisma migrate deploy` from package.json build script (fixes CI failure with dummy DB)
- Adds `vercel.json` with `buildCommand` that includes migration deploy for Vercel only
- CI uses `npm run build` → `prisma generate && next build` (no DB connection needed)
- Vercel uses `buildCommand` → `prisma migrate deploy && prisma generate && next build` (real DB)

## Root Cause
PR #23 added `prisma migrate deploy` to the build script. CI workflow uses a dummy `DATABASE_URL` (`localhost:5432/dummy`) for the build step — there's no real PostgreSQL in CI, so `prisma migrate deploy` fails with `P1001: Can't reach database server`.

## Test plan
- [x] 389/389 unit tests passing
- [x] TypeScript clean
- [x] CI build will pass (no migrate in build script)
- [x] Vercel deployments will auto-apply migrations (vercel.json buildCommand)