### PR TITLE
fix(compute): validator moniker and pagination in jobs explorer

### DIFF
--- a/src/app/api/compute/jobs/route.ts
+++ b/src/app/api/compute/jobs/route.ts
@@ -2,7 +2,15 @@ import { NextRequest } from "next/server";
 import { withRateLimit, jsonResponse } from "@/lib/api-helpers";
 import { parseIntParam, parseStringParam } from "@/lib/validation";
 import { fetchYaci } from "@/lib/yaci";
-import type { ComputeJob } from "@/types";
+import type { ComputeJob, ComputeLeaderboardEntry } from "@/types";
+
+type MonikerEntry = Pick<ComputeLeaderboardEntry, "target_validator" | "moniker">;
+
+// RPC endpoint returns { data, pagination } — we only need pagination.total
+interface RpcCountResponse {
+  data: unknown[];
+  pagination: { total: number };
+}
 
 export async function GET(request: NextRequest) {
   const rl = withRateLimit(request);
@@ -14,18 +22,27 @@ export async function GET(request: NextRequest) {
   const status = parseStringParam(params.get("status"), ["PENDING", "COMPLETED", "FAILED"]);
   const validator = params.get("validator") || undefined;
 
-  // Use PostgREST table endpoint — supports filters natively.
-  // Fetch limit+1 to determine hasNext without a separate count query.
+  // PostgREST table endpoint for data (supports native filters)
   const filters: string[] = [];
   if (validator) filters.push(`target_validator=eq.${encodeURIComponent(validator)}`);
   if (status) filters.push(`status=eq.${status}`);
-
   const filterStr = filters.length > 0 ? `&${filters.join("&")}` : "";
-  const path = `/compute_jobs?limit=${limit + 1}&offset=${offset}&order=created_at.desc${filterStr}`;
+  const jobsPath = `/compute_jobs?limit=${limit + 1}&offset=${offset}&order=created_at.desc${filterStr}`;
 
-  const result = await fetchYaci<ComputeJob[]>(path);
+  // RPC endpoint for filtered total count (_limit=0 returns pagination.total)
+  const rpcFilters: string[] = ["_limit=0", "_offset=0"];
+  if (status) rpcFilters.push(`_status=${status}`);
+  if (validator) rpcFilters.push(`_validator=${encodeURIComponent(validator)}`);
+  const countPath = `/rpc/get_compute_jobs?${rpcFilters.join("&")}`;
 
-  if (!result.ok) {
+  // Fetch jobs, count, and moniker map in parallel
+  const [jobsResult, countResult, monikerResult] = await Promise.all([
+    fetchYaci<ComputeJob[]>(jobsPath),
+    fetchYaci<RpcCountResponse>(countPath),
+    fetchYaci<MonikerEntry[]>("/compute_leaderboard?select=target_validator,moniker"),
+  ]);
+
+  if (!jobsResult.ok) {
     return jsonResponse(
       { error: "Compute jobs temporarily unavailable" },
       rl.headers,
@@ -34,10 +51,19 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const hasNext = result.data.length > limit;
-  const jobs = hasNext ? result.data.slice(0, limit) : result.data;
+  const hasNext = jobsResult.data.length > limit;
+  const jobs = hasNext ? jobsResult.data.slice(0, limit) : jobsResult.data;
+  const total = countResult.ok ? countResult.data.pagination.total : null;
 
-  return jsonResponse({ jobs, hasNext, limit, offset }, rl.headers, 200, {
+  // Build moniker lookup — gracefully empty if leaderboard call failed
+  const monikers: Record<string, string> = {};
+  if (monikerResult.ok) {
+    for (const entry of monikerResult.data) {
+      if (entry.moniker) monikers[entry.target_validator] = entry.moniker;
+    }
+  }
+
+  return jsonResponse({ jobs, hasNext, total, monikers, limit, offset }, rl.headers, 200, {
     sMaxAge: 10,
     staleWhileRevalidate: 30,
   });

--- a/src/app/dashboard/jobs/page.tsx
+++ b/src/app/dashboard/jobs/page.tsx
@@ -169,9 +169,9 @@ export default function ComputeJobsPage() {
                     <TableCell>
                       <Link
                         href={`/dashboard/validators/${job.target_validator}`}
-                        className="font-mono text-sm text-soft-violet hover:underline"
+                        className="text-sm text-soft-violet hover:underline"
                       >
-                        {truncateAddress(job.target_validator)}
+                        {data.monikers[job.target_validator] || truncateAddress(job.target_validator)}
                       </Link>
                     </TableCell>
                     <TableCell className="text-sm text-mist">
@@ -192,6 +192,12 @@ export default function ComputeJobsPage() {
             <div className="flex items-center justify-between border-t border-slate-DEFAULT/20 px-4 py-3">
               <p className="text-sm text-dusty-lavender/50">
                 Page {Math.floor(offset / limit) + 1}
+                {data.total != null && ` of ${Math.ceil(data.total / limit).toLocaleString()}`}
+                {data.total != null && (
+                  <span className="ml-2 text-dusty-lavender/30">
+                    ({data.total.toLocaleString()} jobs)
+                  </span>
+                )}
               </p>
               <div className="flex gap-2">
                 <Button

--- a/src/hooks/use-compute.ts
+++ b/src/hooks/use-compute.ts
@@ -49,6 +49,8 @@ export function useComputeStats() {
 interface ComputeJobsListResponse {
   jobs: ComputeJob[];
   hasNext: boolean;
+  total: number | null;
+  monikers: Record<string, string>;
   limit: number;
   offset: number;
 }

--- a/tests/unit/api/compute-jobs.test.ts
+++ b/tests/unit/api/compute-jobs.test.ts
@@ -39,16 +39,38 @@ const SAMPLE_JOB = {
   updated_at: "2026-03-26T13:55:48.235161+00:00",
 };
 
+const COUNT_RESPONSE = {
+  data: [],
+  pagination: { total: 2620000, limit: 0, offset: 0, has_next: true, has_prev: false },
+};
+
+const MONIKER_RESPONSE = [
+  { target_validator: "raivaloper1abc", moniker: "TestValidator" },
+];
+
+/** Mock fetchYaci to return different responses based on the path */
+function mockFetchYaci(overrides?: { jobs?: unknown; count?: unknown; monikers?: unknown }) {
+  vi.mocked(fetchYaci).mockImplementation((path: string) => {
+    if (path.startsWith("/compute_jobs")) {
+      return Promise.resolve({ ok: true, data: overrides?.jobs ?? [SAMPLE_JOB] });
+    }
+    if (path.startsWith("/rpc/get_compute_jobs")) {
+      return Promise.resolve({ ok: true, data: overrides?.count ?? COUNT_RESPONSE });
+    }
+    if (path.startsWith("/compute_leaderboard")) {
+      return Promise.resolve({ ok: true, data: overrides?.monikers ?? MONIKER_RESPONSE });
+    }
+    return Promise.resolve({ ok: false, error: "network" });
+  });
+}
+
 describe("GET /api/compute/jobs", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("returns jobs from PostgREST table endpoint", async () => {
-    vi.mocked(fetchYaci).mockResolvedValue({
-      ok: true,
-      data: [SAMPLE_JOB],
-    });
+  it("returns jobs with moniker map and total", async () => {
+    mockFetchYaci();
 
     const { GET } = await import("@/app/api/compute/jobs/route");
     const req = new NextRequest("http://localhost/api/compute/jobs");
@@ -59,14 +81,15 @@ describe("GET /api/compute/jobs", () => {
     expect(body.jobs).toHaveLength(1);
     expect(body.jobs[0].job_id).toBe(970475);
     expect(body.hasNext).toBe(false);
+    expect(body.total).toBe(2620000);
+    expect(body.monikers).toEqual({ raivaloper1abc: "TestValidator" });
     expect(body.limit).toBe(20);
     expect(body.offset).toBe(0);
   });
 
   it("sets hasNext when more results exist (limit+1 trick)", async () => {
-    // Route requests limit+1 (21), receiving 21 means hasNext=true
     const jobs = Array.from({ length: 21 }, (_, i) => ({ ...SAMPLE_JOB, job_id: i }));
-    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: jobs });
+    mockFetchYaci({ jobs });
 
     const { GET } = await import("@/app/api/compute/jobs/route");
     const req = new NextRequest("http://localhost/api/compute/jobs");
@@ -74,34 +97,60 @@ describe("GET /api/compute/jobs", () => {
     const body = await res.json();
 
     expect(body.hasNext).toBe(true);
-    expect(body.jobs).toHaveLength(20); // sliced to limit
+    expect(body.jobs).toHaveLength(20);
   });
 
-  it("passes status filter to yaci", async () => {
-    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: [] });
+  it("passes status filter to table endpoint and RPC count", async () => {
+    mockFetchYaci({ jobs: [] });
 
     const { GET } = await import("@/app/api/compute/jobs/route");
     const req = new NextRequest("http://localhost/api/compute/jobs?status=COMPLETED&limit=5");
     await GET(req);
 
-    const calledPath = vi.mocked(fetchYaci).mock.calls[0][0];
-    expect(calledPath).toContain("status=eq.COMPLETED");
-    expect(calledPath).toContain("limit=6"); // limit+1
-    expect(calledPath).toContain("/compute_jobs?");
+    const calls = vi.mocked(fetchYaci).mock.calls.map((c) => c[0]);
+    const jobsCall = calls.find((p) => p.startsWith("/compute_jobs"));
+    const countCall = calls.find((p) => p.startsWith("/rpc/get_compute_jobs"));
+
+    expect(jobsCall).toContain("status=eq.COMPLETED");
+    expect(jobsCall).toContain("limit=6"); // limit+1
+    expect(countCall).toContain("_status=COMPLETED");
   });
 
-  it("passes validator filter to yaci", async () => {
-    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: [] });
+  it("passes validator filter to both endpoints", async () => {
+    mockFetchYaci({ jobs: [] });
 
     const { GET } = await import("@/app/api/compute/jobs/route");
     const req = new NextRequest("http://localhost/api/compute/jobs?validator=raivaloper1abc");
     await GET(req);
 
-    const calledPath = vi.mocked(fetchYaci).mock.calls[0][0];
-    expect(calledPath).toContain("target_validator=eq.raivaloper1abc");
+    const calls = vi.mocked(fetchYaci).mock.calls.map((c) => c[0]);
+    const jobsCall = calls.find((p) => p.startsWith("/compute_jobs"));
+    const countCall = calls.find((p) => p.startsWith("/rpc/get_compute_jobs"));
+
+    expect(jobsCall).toContain("target_validator=eq.raivaloper1abc");
+    expect(countCall).toContain("_validator=raivaloper1abc");
   });
 
-  it("returns 502 when yaci is unreachable", async () => {
+  it("returns total:null when count call fails", async () => {
+    vi.mocked(fetchYaci).mockImplementation((path: string) => {
+      if (path.startsWith("/compute_jobs")) {
+        return Promise.resolve({ ok: true, data: [SAMPLE_JOB] });
+      }
+      // count and moniker calls fail
+      return Promise.resolve({ ok: false, error: "timeout" });
+    });
+
+    const { GET } = await import("@/app/api/compute/jobs/route");
+    const req = new NextRequest("http://localhost/api/compute/jobs");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.total).toBeNull();
+    expect(body.monikers).toEqual({});
+  });
+
+  it("returns 502 when jobs call fails", async () => {
     vi.mocked(fetchYaci).mockResolvedValue({ ok: false, error: "timeout" });
 
     const { GET } = await import("@/app/api/compute/jobs/route");


### PR DESCRIPTION
## Summary

- Show validator moniker instead of raw address in Compute Jobs table
- Add filtered total count via RPC endpoint for accurate "Page X of Y (Z jobs)" display
- Parallel fetch for moniker map + count + jobs data
- Graceful fallback: truncated address when moniker unavailable, hidden total when count fails

## Test plan

- [ ] Verify validator names show in Compute Jobs table instead of addresses
- [ ] Verify "Page X of Y (Z jobs)" appears in pagination footer
- [ ] Verify filtering by status still shows correct page count
- [ ] CI: 1275/1275 tests pass, tsc and lint clean