### PR TITLE
feat: Yaci Explorer network analytics, delegation redesign, validator enrichment

### DIFF
--- a/src/app/api/stats/block-metrics/route.ts
+++ b/src/app/api/stats/block-metrics/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { withRateLimit, jsonResponse } from "@/lib/api-helpers";
+import { fetchYaci } from "@/lib/yaci";
+import type { YaciBlockMetric } from "@/types";
+
+export async function GET(request: NextRequest) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const result = await fetchYaci<YaciBlockMetric[]>(
+    "/block_metrics?order=height.desc&limit=100",
+  );
+
+  if (!result.ok) {
+    return jsonResponse(
+      { error: "Block metrics temporarily unavailable" },
+      rl.headers,
+      502,
+      { cache: false },
+    );
+  }
+
+  return jsonResponse(result.data, rl.headers, 200, {
+    sMaxAge: 30,
+    staleWhileRevalidate: 60,
+  });
+}

--- a/src/app/api/stats/daily-rewards/route.ts
+++ b/src/app/api/stats/daily-rewards/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { withRateLimit, jsonResponse } from "@/lib/api-helpers";
+import { fetchYaci } from "@/lib/yaci";
+import type { YaciDailyRewards } from "@/types";
+
+export async function GET(request: NextRequest) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const result = await fetchYaci<YaciDailyRewards[]>(
+    "/rt_daily_rewards?order=date.desc&limit=30",
+  );
+
+  if (!result.ok) {
+    return jsonResponse(
+      { error: "Daily rewards data temporarily unavailable" },
+      rl.headers,
+      502,
+      { cache: false },
+    );
+  }
+
+  return jsonResponse(result.data, rl.headers, 200, {
+    sMaxAge: 60,
+    staleWhileRevalidate: 120,
+  });
+}

--- a/src/app/api/stats/fee-revenue/route.ts
+++ b/src/app/api/stats/fee-revenue/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { withRateLimit, jsonResponse } from "@/lib/api-helpers";
+import { fetchYaci } from "@/lib/yaci";
+import type { YaciFeeRevenue } from "@/types";
+
+export async function GET(request: NextRequest) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const result = await fetchYaci<YaciFeeRevenue[]>("/fee_revenue");
+
+  if (!result.ok) {
+    return jsonResponse(
+      { error: "Fee revenue data temporarily unavailable" },
+      rl.headers,
+      502,
+      { cache: false },
+    );
+  }
+
+  const revenue = result.data[0] ?? null;
+
+  return jsonResponse(revenue, rl.headers, 200, {
+    sMaxAge: 120,
+    staleWhileRevalidate: 240,
+  });
+}

--- a/src/app/api/stats/gas-distribution/route.ts
+++ b/src/app/api/stats/gas-distribution/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest } from "next/server";
+import { withRateLimit, jsonResponse } from "@/lib/api-helpers";
+import { fetchYaci } from "@/lib/yaci";
+import type { YaciGasDistribution } from "@/types";
+
+export async function GET(request: NextRequest) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const result = await fetchYaci<YaciGasDistribution[]>("/gas_usage_distribution");
+
+  if (!result.ok) {
+    return jsonResponse(
+      { error: "Gas distribution data temporarily unavailable" },
+      rl.headers,
+      502,
+      { cache: false },
+    );
+  }
+
+  return jsonResponse(result.data, rl.headers, 200, {
+    sMaxAge: 120,
+    staleWhileRevalidate: 240,
+  });
+}

--- a/src/app/api/stats/message-types/route.ts
+++ b/src/app/api/stats/message-types/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { withRateLimit, jsonResponse } from "@/lib/api-helpers";
+import { fetchYaci } from "@/lib/yaci";
+import type { YaciMessageTypeStat } from "@/types";
+
+export async function GET(request: NextRequest) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const result = await fetchYaci<YaciMessageTypeStat[]>(
+    "/message_type_stats?order=count.desc&limit=10",
+  );
+
+  if (!result.ok) {
+    return jsonResponse(
+      { error: "Message type stats temporarily unavailable" },
+      rl.headers,
+      502,
+      { cache: false },
+    );
+  }
+
+  return jsonResponse(result.data, rl.headers, 200, {
+    sMaxAge: 120,
+    staleWhileRevalidate: 240,
+  });
+}

--- a/src/app/api/stats/network-overview/route.ts
+++ b/src/app/api/stats/network-overview/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { withRateLimit, jsonResponse } from "@/lib/api-helpers";
+import { fetchYaci } from "@/lib/yaci";
+import type { YaciNetworkOverview } from "@/types";
+
+export async function GET(request: NextRequest) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const result = await fetchYaci<YaciNetworkOverview[]>("/mv_network_overview");
+
+  if (!result.ok) {
+    return jsonResponse(
+      { error: "Network overview temporarily unavailable" },
+      rl.headers,
+      502,
+      { cache: false },
+    );
+  }
+
+  const overview = result.data[0] ?? null;
+
+  return jsonResponse(overview, rl.headers, 200, {
+    sMaxAge: 30,
+    staleWhileRevalidate: 60,
+  });
+}

--- a/src/app/api/stats/tx-daily/route.ts
+++ b/src/app/api/stats/tx-daily/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { withRateLimit, jsonResponse } from "@/lib/api-helpers";
+import { fetchYaci } from "@/lib/yaci";
+import type { YaciDailyTxStats } from "@/types";
+
+export async function GET(request: NextRequest) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const result = await fetchYaci<YaciDailyTxStats[]>(
+    "/daily_tx_stats?order=date.desc&limit=30",
+  );
+
+  if (!result.ok) {
+    return jsonResponse(
+      { error: "Transaction stats temporarily unavailable" },
+      rl.headers,
+      502,
+      { cache: false },
+    );
+  }
+
+  return jsonResponse(result.data, rl.headers, 200, {
+    sMaxAge: 60,
+    staleWhileRevalidate: 120,
+  });
+}

--- a/src/app/api/stats/tx-success-rate/route.ts
+++ b/src/app/api/stats/tx-success-rate/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { withRateLimit, jsonResponse } from "@/lib/api-helpers";
+import { fetchYaci } from "@/lib/yaci";
+import type { YaciTxSuccessRate } from "@/types";
+
+export async function GET(request: NextRequest) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const result = await fetchYaci<YaciTxSuccessRate[]>("/tx_success_rate");
+
+  if (!result.ok) {
+    return jsonResponse(
+      { error: "Success rate data temporarily unavailable" },
+      rl.headers,
+      502,
+      { cache: false },
+    );
+  }
+
+  const stats = result.data[0] ?? null;
+
+  return jsonResponse(stats, rl.headers, 200, {
+    sMaxAge: 60,
+    staleWhileRevalidate: 120,
+  });
+}

--- a/src/app/api/validators/[id]/jailing/route.ts
+++ b/src/app/api/validators/[id]/jailing/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest } from "next/server";
+import { withRateLimit, jsonResponse } from "@/lib/api-helpers";
+import { fetchYaci } from "@/lib/yaci";
+import type { YaciJailingEvent } from "@/types";
+
+interface YaciValidator {
+  operator_address: string;
+  consensus_address: string;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const { id } = await params;
+  const encoded = encodeURIComponent(id);
+
+  // Jailing events use validator_address (consensus format, e.g. raivalcons1...).
+  // We receive an operator address (raivaloper1...), so first resolve the consensus address.
+  const validatorResult = await fetchYaci<YaciValidator[]>(
+    `/validators?operator_address=eq.${encoded}&select=operator_address,consensus_address&limit=1`,
+  );
+
+  if (!validatorResult.ok) {
+    return jsonResponse(
+      { error: "Jailing data temporarily unavailable" },
+      rl.headers,
+      502,
+      { cache: false },
+    );
+  }
+
+  const validator = validatorResult.data[0];
+  if (!validator?.consensus_address) {
+    // No consensus address found — return empty (not an error)
+    return jsonResponse([], rl.headers, 200, {
+      sMaxAge: 60,
+      staleWhileRevalidate: 120,
+    });
+  }
+
+  const consensusEncoded = encodeURIComponent(validator.consensus_address);
+  const result = await fetchYaci<YaciJailingEvent[]>(
+    `/jailing_events?validator_address=eq.${consensusEncoded}&order=height.desc&limit=50`,
+  );
+
+  if (!result.ok) {
+    return jsonResponse(
+      { error: "Jailing data temporarily unavailable" },
+      rl.headers,
+      502,
+      { cache: false },
+    );
+  }
+
+  return jsonResponse(result.data, rl.headers, 200, {
+    sMaxAge: 60,
+    staleWhileRevalidate: 120,
+  });
+}

--- a/src/app/api/validators/[id]/rewards/route.ts
+++ b/src/app/api/validators/[id]/rewards/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest } from "next/server";
+import { withRateLimit, jsonResponse } from "@/lib/api-helpers";
+import { fetchYaci } from "@/lib/yaci";
+import type { YaciValidatorReward } from "@/types";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const { id } = await params;
+  const encoded = encodeURIComponent(id);
+
+  const result = await fetchYaci<YaciValidatorReward[]>(
+    `/validator_rewards?validator_address=eq.${encoded}&order=height.desc&limit=100`,
+  );
+
+  if (!result.ok) {
+    return jsonResponse(
+      { error: "Reward data temporarily unavailable" },
+      rl.headers,
+      502,
+      { cache: false },
+    );
+  }
+
+  return jsonResponse(result.data, rl.headers, 200, {
+    sMaxAge: 60,
+    staleWhileRevalidate: 120,
+  });
+}

--- a/src/app/api/validators/[id]/signing/route.ts
+++ b/src/app/api/validators/[id]/signing/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from "next/server";
+import { withRateLimit, jsonResponse } from "@/lib/api-helpers";
+import { fetchYaci } from "@/lib/yaci";
+import type { YaciValidatorSigningStats } from "@/types";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const rl = withRateLimit(request);
+  if ("response" in rl) return rl.response;
+
+  const { id } = await params;
+  const encoded = encodeURIComponent(id);
+
+  const result = await fetchYaci<YaciValidatorSigningStats[]>(
+    `/mv_validator_signing_stats?operator_address=eq.${encoded}`,
+  );
+
+  if (!result.ok) {
+    return jsonResponse(
+      { error: "Signing stats temporarily unavailable" },
+      rl.headers,
+      502,
+      { cache: false },
+    );
+  }
+
+  const stats = result.data[0] ?? null;
+
+  return jsonResponse(stats, rl.headers, 200, {
+    sMaxAge: 60,
+    staleWhileRevalidate: 120,
+  });
+}

--- a/src/app/dashboard/delegations/page.tsx
+++ b/src/app/dashboard/delegations/page.tsx
@@ -12,14 +12,12 @@ export default function DelegationsPage() {
         title="Delegations"
         description="Stake movements, delegation flow, and whale detection"
       />
-      <div className="grid gap-6 lg:grid-cols-3">
-        <div className="space-y-6 lg:col-span-2">
-          <DelegationFlow />
-          <DelegationList />
-        </div>
-        <div className="lg:col-span-1">
-          <WhaleMovements />
-        </div>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <DelegationFlow />
+        <DelegationList />
+      </div>
+      <div className="mt-6">
+        <WhaleMovements />
       </div>
     </div>
   );

--- a/src/app/dashboard/network/page.tsx
+++ b/src/app/dashboard/network/page.tsx
@@ -1,5 +1,6 @@
 import { PageHeader } from "@/components/dashboard/page-header";
 import { NetworkOverview } from "@/components/dashboard/network-overview";
+import { NetworkActivity } from "@/components/dashboard/network-activity";
 
 export const metadata = {
   title: "Network | Panoptes",
@@ -14,6 +15,9 @@ export default function NetworkPage() {
         description="Chain statistics, validator trends, and staking analytics"
       />
       <NetworkOverview />
+      <div className="mt-6">
+        <NetworkActivity />
+      </div>
     </div>
   );
 }

--- a/src/components/charts/block-time-chart.tsx
+++ b/src/components/charts/block-time-chart.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+import { ChartTooltip } from "./chart-tooltip";
+import type { YaciBlockMetric } from "@/types";
+
+interface BlockTimeChartProps {
+  data: YaciBlockMetric[];
+}
+
+export function BlockTimeChart({ data }: BlockTimeChartProps) {
+  // Compute deltas only between consecutive height pairs where both have non-null block_time.
+  // This avoids inflated deltas when null entries exist mid-series.
+  const sorted = data.slice().reverse();
+  const chartData: { height: number; seconds: number }[] = [];
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = sorted[i - 1];
+    const curr = sorted[i];
+    if (prev.block_time === null || curr.block_time === null) continue;
+    if (curr.height !== prev.height + 1) continue; // skip non-consecutive
+    const seconds = Math.max(0, (new Date(curr.block_time).getTime() - new Date(prev.block_time).getTime()) / 1000);
+    chartData.push({ height: curr.height, seconds });
+  }
+
+  if (chartData.length === 0) return null;
+
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <LineChart data={chartData} margin={{ top: 5, right: 5, bottom: 5, left: 5 }}>
+        <CartesianGrid stroke="rgba(71, 85, 105, 0.1)" strokeDasharray="3 3" />
+        <XAxis
+          dataKey="height"
+          tickFormatter={(v) => `#${Number(v).toLocaleString()}`}
+          tick={{ fill: "rgba(196, 181, 253, 0.5)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          minTickGap={40}
+        />
+        <YAxis
+          tickFormatter={(v) => `${Number(v).toFixed(1)}s`}
+          tick={{ fill: "rgba(196, 181, 253, 0.5)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          width={50}
+        />
+        <Tooltip
+          content={
+            <ChartTooltip
+              labelFormatter={(label) => `Block #${Number(label).toLocaleString()}`}
+              formatter={(value) => `${Number(value).toFixed(2)}s`}
+            />
+          }
+        />
+        <Line
+          type="monotone"
+          dataKey="seconds"
+          stroke="#ec4899"
+          strokeWidth={1.5}
+          dot={false}
+          name="Block Time"
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/charts/daily-rewards-chart.tsx
+++ b/src/components/charts/daily-rewards-chart.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useId } from "react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Legend,
+} from "recharts";
+import { ChartTooltip } from "./chart-tooltip";
+import { formatChartDate } from "@/lib/time";
+import type { YaciDailyRewards } from "@/types";
+
+interface DailyRewardsChartProps {
+  data: YaciDailyRewards[];
+}
+
+const ARAI_DIVISOR = 1e18;
+
+export function DailyRewardsChart({ data }: DailyRewardsChartProps) {
+  const gradientRewards = useId();
+  const gradientCommission = useId();
+
+  const chartData = data
+    .slice()
+    .reverse()
+    .map((item) => ({
+      date: item.date,
+      rewards: Number(item.total_rewards) / ARAI_DIVISOR,
+      commission: Number(item.total_commission) / ARAI_DIVISOR,
+    }));
+
+  if (chartData.length === 0) return null;
+
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <AreaChart data={chartData} margin={{ top: 5, right: 5, bottom: 5, left: 5 }}>
+        <defs>
+          <linearGradient id={gradientRewards} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#8B5CF6" stopOpacity={0.3} />
+            <stop offset="100%" stopColor="#8B5CF6" stopOpacity={0} />
+          </linearGradient>
+          <linearGradient id={gradientCommission} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#D97706" stopOpacity={0.3} />
+            <stop offset="100%" stopColor="#D97706" stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid stroke="rgba(71, 85, 105, 0.1)" strokeDasharray="3 3" />
+        <XAxis
+          dataKey="date"
+          tickFormatter={formatChartDate}
+          tick={{ fill: "rgba(196, 181, 253, 0.5)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          minTickGap={40}
+        />
+        <YAxis
+          tickFormatter={(v) => {
+            if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
+            if (v >= 1e3) return `${(v / 1e3).toFixed(0)}K`;
+            return v.toFixed(0);
+          }}
+          tick={{ fill: "rgba(196, 181, 253, 0.5)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          width={60}
+        />
+        <Tooltip
+          content={
+            <ChartTooltip
+              labelFormatter={formatChartDate}
+              formatter={(value) => `${Number(value).toFixed(2)} RAI`}
+            />
+          }
+        />
+        <Legend
+          wrapperStyle={{ fontSize: 11, color: "rgba(196, 181, 253, 0.5)" }}
+        />
+        <Area
+          type="monotone"
+          dataKey="rewards"
+          stroke="#8B5CF6"
+          strokeWidth={2}
+          fill={`url(#${gradientRewards})`}
+          name="Rewards"
+        />
+        <Area
+          type="monotone"
+          dataKey="commission"
+          stroke="#D97706"
+          strokeWidth={2}
+          fill={`url(#${gradientCommission})`}
+          name="Commission"
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/charts/daily-tx-chart.tsx
+++ b/src/components/charts/daily-tx-chart.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useId } from "react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+import { ChartTooltip } from "./chart-tooltip";
+import { formatChartDate } from "@/lib/time";
+import type { YaciDailyTxStats } from "@/types";
+
+interface DailyTxChartProps {
+  data: YaciDailyTxStats[];
+}
+
+export function DailyTxChart({ data }: DailyTxChartProps) {
+  const gradientId = useId();
+  const chartData = data
+    .slice()
+    .reverse()
+    .map((item) => ({
+      date: item.date,
+      txs: item.total_txs,
+    }));
+
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <AreaChart data={chartData} margin={{ top: 5, right: 5, bottom: 5, left: 5 }}>
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="#14b8a6" stopOpacity={0.3} />
+            <stop offset="100%" stopColor="#14b8a6" stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid stroke="rgba(71, 85, 105, 0.1)" strokeDasharray="3 3" />
+        <XAxis
+          dataKey="date"
+          tickFormatter={formatChartDate}
+          tick={{ fill: "rgba(196, 181, 253, 0.5)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          minTickGap={40}
+        />
+        <YAxis
+          tickFormatter={(v) => {
+            if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
+            if (v >= 1e3) return `${(v / 1e3).toFixed(0)}K`;
+            return String(Math.round(v));
+          }}
+          tick={{ fill: "rgba(196, 181, 253, 0.5)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          width={60}
+        />
+        <Tooltip
+          content={
+            <ChartTooltip
+              labelFormatter={formatChartDate}
+              formatter={(value) => value.toLocaleString()}
+            />
+          }
+        />
+        <Area
+          type="monotone"
+          dataKey="txs"
+          stroke="#14b8a6"
+          strokeWidth={2}
+          fill={`url(#${gradientId})`}
+          name="Transactions"
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/charts/gas-distribution-chart.tsx
+++ b/src/components/charts/gas-distribution-chart.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+import { ChartTooltip } from "./chart-tooltip";
+import type { YaciGasDistribution } from "@/types";
+
+interface GasDistributionChartProps {
+  data: YaciGasDistribution[];
+}
+
+export function GasDistributionChart({ data }: GasDistributionChartProps) {
+  const chartData = data.map((item) => ({
+    range: item.gas_range,
+    count: item.count,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <BarChart data={chartData} margin={{ top: 5, right: 5, bottom: 5, left: 5 }}>
+        <CartesianGrid stroke="rgba(71, 85, 105, 0.1)" strokeDasharray="3 3" />
+        <XAxis
+          dataKey="range"
+          tick={{ fill: "rgba(196, 181, 253, 0.5)", fontSize: 10 }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <YAxis
+          tickFormatter={(v) => {
+            if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
+            if (v >= 1e3) return `${(v / 1e3).toFixed(0)}K`;
+            return String(v);
+          }}
+          tick={{ fill: "rgba(196, 181, 253, 0.5)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          width={60}
+        />
+        <Tooltip
+          content={
+            <ChartTooltip
+              labelFormatter={(label) => `Gas: ${label}`}
+              formatter={(value) => value.toLocaleString()}
+            />
+          }
+        />
+        <Bar
+          dataKey="count"
+          fill="#D97706"
+          radius={[4, 4, 0, 0]}
+          name="Transactions"
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/charts/message-type-chart.tsx
+++ b/src/components/charts/message-type-chart.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+import { ChartTooltip } from "./chart-tooltip";
+import type { YaciMessageTypeStat } from "@/types";
+
+interface MessageTypeChartProps {
+  data: YaciMessageTypeStat[];
+}
+
+function shortenMessageType(msgType: string): string {
+  // "/cosmos.staking.v1beta1.MsgDelegate" → "MsgDelegate"
+  const parts = msgType.split(".");
+  return parts[parts.length - 1] ?? msgType;
+}
+
+export function MessageTypeChart({ data }: MessageTypeChartProps) {
+  const chartData = data.map((item) => ({
+    name: shortenMessageType(item.message_type),
+    count: item.count,
+    fullName: item.message_type,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <BarChart data={chartData} layout="vertical" margin={{ top: 5, right: 15, bottom: 5, left: 5 }}>
+        <CartesianGrid stroke="rgba(71, 85, 105, 0.1)" strokeDasharray="3 3" horizontal={false} />
+        <XAxis
+          type="number"
+          tickFormatter={(v) => {
+            if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
+            if (v >= 1e3) return `${(v / 1e3).toFixed(0)}K`;
+            return String(v);
+          }}
+          tick={{ fill: "rgba(196, 181, 253, 0.5)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+        />
+        <YAxis
+          type="category"
+          dataKey="name"
+          tick={{ fill: "rgba(196, 181, 253, 0.5)", fontSize: 10 }}
+          axisLine={false}
+          tickLine={false}
+          width={120}
+        />
+        <Tooltip
+          content={
+            <ChartTooltip
+              labelFormatter={(label) => label}
+              formatter={(value) => value.toLocaleString()}
+            />
+          }
+        />
+        <Bar
+          dataKey="count"
+          fill="#8B5CF6"
+          radius={[0, 4, 4, 0]}
+          name="Count"
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/charts/reward-history-chart.tsx
+++ b/src/components/charts/reward-history-chart.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Legend,
+} from "recharts";
+import { ChartTooltip } from "./chart-tooltip";
+import type { YaciValidatorReward } from "@/types";
+
+interface RewardHistoryChartProps {
+  data: YaciValidatorReward[];
+}
+
+const ARAI_DIVISOR = 1e18;
+
+export function RewardHistoryChart({ data }: RewardHistoryChartProps) {
+  const chartData = data
+    .slice()
+    .reverse()
+    .map((item) => ({
+      height: item.height,
+      rewards: Number(item.rewards) / ARAI_DIVISOR,
+      commission: Number(item.commission) / ARAI_DIVISOR,
+    }));
+
+  if (chartData.length === 0) return null;
+
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <BarChart data={chartData} margin={{ top: 5, right: 5, bottom: 5, left: 5 }}>
+        <CartesianGrid stroke="rgba(71, 85, 105, 0.1)" strokeDasharray="3 3" />
+        <XAxis
+          dataKey="height"
+          tickFormatter={(v) => `#${Number(v).toLocaleString()}`}
+          tick={{ fill: "rgba(196, 181, 253, 0.5)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          minTickGap={40}
+        />
+        <YAxis
+          tickFormatter={(v) => {
+            if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`;
+            if (v >= 1e3) return `${(v / 1e3).toFixed(0)}K`;
+            return v.toFixed(1);
+          }}
+          tick={{ fill: "rgba(196, 181, 253, 0.5)", fontSize: 11 }}
+          axisLine={false}
+          tickLine={false}
+          width={60}
+        />
+        <Tooltip
+          content={
+            <ChartTooltip
+              labelFormatter={(label) => `Block #${Number(label).toLocaleString()}`}
+              formatter={(value) => `${Number(value).toFixed(4)} RAI`}
+            />
+          }
+        />
+        <Legend
+          wrapperStyle={{ fontSize: 11, color: "rgba(196, 181, 253, 0.5)" }}
+        />
+        <Bar dataKey="rewards" fill="#8B5CF6" name="Rewards" radius={[2, 2, 0, 0]} />
+        <Bar dataKey="commission" fill="#D97706" name="Commission" radius={[2, 2, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/dashboard/delegation-flow.tsx
+++ b/src/components/dashboard/delegation-flow.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useDelegationFlow } from "@/hooks/use-delegations";
 import { ErrorState } from "./error-state";
+import { Pagination } from "./pagination";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Loader2, ArrowLeftRight, TrendingUp, TrendingDown } from "lucide-react";
 import { HelpTooltip } from "./help-tooltip";
@@ -10,8 +11,11 @@ import { helpContent } from "@/lib/help-content";
 import { formatAmountShort, truncateAddress } from "@/lib/formatters";
 import { SearchInput } from "./search-input";
 
+const PAGE_SIZE = 10;
+
 export function DelegationFlow() {
   const [search, setSearch] = useState("");
+  const [page, setPage] = useState(0);
   const { data, error, isLoading, mutate } = useDelegationFlow(7);
 
   const flow = data?.flow ?? [];
@@ -21,6 +25,9 @@ export function DelegationFlow() {
         return (v.moniker?.toLowerCase().includes(q)) || v.validatorId.toLowerCase().includes(q);
       })
     : flow;
+  const maxPage = Math.max(0, Math.ceil(filteredFlow.length / PAGE_SIZE) - 1);
+  const safePage = Math.min(page, maxPage);
+  const paginatedFlow = filteredFlow.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE);
 
   if (error) return <ErrorState message="Failed to load delegation flow" onRetry={() => mutate()} />;
 
@@ -52,7 +59,7 @@ export function DelegationFlow() {
           </CardTitle>
           <SearchInput
             placeholder="Search validator..."
-            onSearch={setSearch}
+            onSearch={(q) => { setSearch(q); setPage(0); }}
             className="sm:w-64"
           />
         </div>
@@ -68,7 +75,7 @@ export function DelegationFlow() {
               <HelpTooltip content={helpContent.delegations.fields.churnRate} side="left" />
             </span>
           </div>
-          {filteredFlow.map((v) => (
+          {paginatedFlow.map((v) => (
             <div key={v.validatorId} className="grid grid-cols-2 gap-4 rounded bg-slate-dark/20 px-3 py-2 text-xs md:grid-cols-4">
               <span className="font-mono text-dusty-lavender truncate" title={v.validatorId}>{v.moniker || truncateAddress(v.validatorId, 8, 6)}</span>
               <span className="text-right text-mist">{v.latestDelegators}</span>
@@ -88,6 +95,16 @@ export function DelegationFlow() {
             </div>
           ))}
         </div>
+        {filteredFlow.length > PAGE_SIZE && (
+          <div className="mt-4">
+            <Pagination
+              total={filteredFlow.length}
+              limit={PAGE_SIZE}
+              offset={safePage * PAGE_SIZE}
+              onPageChange={(offset) => setPage(Math.floor(offset / PAGE_SIZE))}
+            />
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/components/dashboard/network-activity.tsx
+++ b/src/components/dashboard/network-activity.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import {
+  useDailyTxStats,
+  useTxSuccessRate,
+  useMessageTypeStats,
+  useGasDistribution,
+  useFeeRevenue,
+  useBlockMetrics,
+  useDailyRewards,
+} from "@/hooks/use-network-analytics";
+import { StatCard } from "./stat-card";
+import { HelpTooltip } from "./help-tooltip";
+import { helpContent } from "@/lib/help-content";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { formatAmountShort } from "@/lib/formatters";
+import { Activity, CheckCircle, Coins, Fuel, BarChart3, Clock, TrendingUp } from "lucide-react";
+
+const ChartSkeleton = () => <Skeleton className="h-64 w-full rounded-lg bg-deep-iris/20" />;
+
+const DailyTxChart = dynamic(
+  () => import("@/components/charts/daily-tx-chart").then((m) => m.DailyTxChart),
+  { ssr: false, loading: ChartSkeleton },
+);
+const MessageTypeChart = dynamic(
+  () => import("@/components/charts/message-type-chart").then((m) => m.MessageTypeChart),
+  { ssr: false, loading: ChartSkeleton },
+);
+const GasDistributionChart = dynamic(
+  () => import("@/components/charts/gas-distribution-chart").then((m) => m.GasDistributionChart),
+  { ssr: false, loading: ChartSkeleton },
+);
+const BlockTimeChart = dynamic(
+  () => import("@/components/charts/block-time-chart").then((m) => m.BlockTimeChart),
+  { ssr: false, loading: ChartSkeleton },
+);
+const DailyRewardsChart = dynamic(
+  () => import("@/components/charts/daily-rewards-chart").then((m) => m.DailyRewardsChart),
+  { ssr: false, loading: ChartSkeleton },
+);
+
+export function NetworkActivity() {
+  const { data: txStats } = useDailyTxStats();
+  const { data: successRate } = useTxSuccessRate();
+  const { data: messageTypes } = useMessageTypeStats();
+  const { data: gasDist } = useGasDistribution();
+  const { data: feeRevenue } = useFeeRevenue();
+  const { data: blockMetrics } = useBlockMetrics();
+  const { data: dailyRewards } = useDailyRewards();
+
+  // Silently hide if all Yaci data is unavailable
+  const hasAnyData = txStats || successRate || messageTypes || gasDist || feeRevenue || blockMetrics || dailyRewards;
+  if (!hasAnyData) return null;
+
+  return (
+    <div className="space-y-6">
+      {/* Stat cards row */}
+      {(successRate || feeRevenue) && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {successRate && (
+            <StatCard
+              title={
+                <span className="flex items-center gap-1">
+                  TX Success Rate
+                  <HelpTooltip content={helpContent.network.fields.txSuccessRate} side="right" />
+                </span>
+              }
+              value={`${successRate.success_rate_percent.toFixed(2)}%`}
+              subtitle={`${successRate.failed.toLocaleString()} failed of ${successRate.total.toLocaleString()}`}
+              icon={<CheckCircle className="size-4" />}
+            />
+          )}
+          {successRate && (
+            <StatCard
+              title="Total Transactions"
+              value={successRate.total.toLocaleString()}
+              subtitle={`${successRate.successful.toLocaleString()} successful`}
+              icon={<Activity className="size-4" />}
+            />
+          )}
+          {feeRevenue && (
+            <StatCard
+              title={
+                <span className="flex items-center gap-1">
+                  Fee Revenue
+                  <HelpTooltip content={helpContent.network.fields.feeRevenue} side="right" />
+                </span>
+              }
+              value={formatAmountShort(feeRevenue.total_amount)}
+              subtitle={feeRevenue.denom.toUpperCase()}
+              icon={<Coins className="size-4" />}
+            />
+          )}
+        </div>
+      )}
+
+      {/* Chart row 1 */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        {txStats && txStats.length > 0 && (
+          <Card className="border-slate-DEFAULT/20 bg-midnight-plum">
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-sm font-medium text-dusty-lavender/70">
+                <BarChart3 className="size-4" />
+                Daily TX Volume (30d)
+                <HelpTooltip content={helpContent.network.fields.dailyTxVolume} side="right" />
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <DailyTxChart data={txStats} />
+            </CardContent>
+          </Card>
+        )}
+        {messageTypes && messageTypes.length > 0 && (
+          <Card className="border-slate-DEFAULT/20 bg-midnight-plum">
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-sm font-medium text-dusty-lavender/70">
+                <Activity className="size-4" />
+                Message Types
+                <HelpTooltip content={helpContent.network.fields.messageTypes} side="right" />
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <MessageTypeChart data={messageTypes} />
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      {/* Chart row 2 */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        {gasDist && gasDist.length > 0 && (
+          <Card className="border-slate-DEFAULT/20 bg-midnight-plum">
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-sm font-medium text-dusty-lavender/70">
+                <Fuel className="size-4" />
+                Gas Usage Distribution
+                <HelpTooltip content={helpContent.network.fields.gasDistribution} side="right" />
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <GasDistributionChart data={gasDist} />
+            </CardContent>
+          </Card>
+        )}
+        {blockMetrics && blockMetrics.length > 1 && (
+          <Card className="border-slate-DEFAULT/20 bg-midnight-plum">
+            <CardHeader className="pb-2">
+              <CardTitle className="flex items-center gap-2 text-sm font-medium text-dusty-lavender/70">
+                <Clock className="size-4" />
+                Block Time Trend (Last 100)
+                <HelpTooltip content={helpContent.network.fields.blockTime} side="right" />
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <BlockTimeChart data={blockMetrics} />
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      {/* Chart row 3: Daily Rewards */}
+      {dailyRewards && dailyRewards.length > 0 && (
+        <Card className="border-slate-DEFAULT/20 bg-midnight-plum">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-sm font-medium text-dusty-lavender/70">
+              <TrendingUp className="size-4" />
+              Daily Rewards & Commission (30d)
+              <HelpTooltip content={helpContent.network.fields.dailyRewards} side="right" />
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <DailyRewardsChart data={dailyRewards} />
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/overview.tsx
+++ b/src/components/dashboard/overview.tsx
@@ -8,6 +8,7 @@ import { useAnomalies } from "@/hooks/use-anomalies";
 import { useSloSummary } from "@/hooks/use-slos";
 import { useIncidentSummary } from "@/hooks/use-incidents";
 import { useComputeStats } from "@/hooks/use-compute";
+import { useYaciNetworkOverview } from "@/hooks/use-network-analytics";
 import { useHistorySparklines } from "@/hooks/use-history-sparklines";
 import { StatCard } from "./stat-card";
 import { ErrorState } from "./error-state";
@@ -44,6 +45,7 @@ import {
   Cpu,
   CheckCircle,
   Clock,
+  Users,
 } from "lucide-react";
 
 export function Overview() {
@@ -61,6 +63,7 @@ export function Overview() {
   const { data: sloSummary } = useSloSummary();
   const { data: incidentSummary } = useIncidentSummary();
   const { data: computeStats } = useComputeStats();
+  const { data: yaciOverview } = useYaciNetworkOverview();
 
   const current = stats?.current;
   const history = useMemo(() => stats?.history ?? [], [stats?.history]);
@@ -178,6 +181,30 @@ export function Overview() {
             title="Pending Queue"
             value={computeStats.pending_jobs.toLocaleString()}
             subtitle="awaiting processing"
+            icon={<Clock className="size-4" />}
+          />
+        </div>
+      )}
+
+      {/* Yaci network stats */}
+      {yaciOverview && (
+        <div className="grid gap-4 sm:grid-cols-3">
+          <StatCard
+            title="Total Transactions"
+            value={yaciOverview.total_transactions.toLocaleString()}
+            subtitle="across all blocks"
+            icon={<Activity className="size-4" />}
+          />
+          <StatCard
+            title="Unique Addresses"
+            value={yaciOverview.unique_addresses.toLocaleString()}
+            subtitle="distinct accounts"
+            icon={<Users className="size-4" />}
+          />
+          <StatCard
+            title="Avg Block Time"
+            value={`${yaciOverview.avg_block_time.toFixed(2)}s`}
+            subtitle={`${yaciOverview.active_validators} / ${yaciOverview.max_validators} active validators`}
             icon={<Clock className="size-4" />}
           />
         </div>

--- a/src/components/dashboard/validator-detail.tsx
+++ b/src/components/dashboard/validator-detail.tsx
@@ -19,6 +19,18 @@ const ComputeSection = dynamic(
   () => import("@/components/dashboard/compute-section").then((m) => m.ComputeSection),
   { ssr: false, loading: () => <Skeleton className="h-48 w-full rounded-lg bg-deep-iris/20" /> },
 );
+const ValidatorSigningStats = dynamic(
+  () => import("@/components/dashboard/validator-signing-stats").then((m) => m.ValidatorSigningStats),
+  { ssr: false },
+);
+const ValidatorJailingTimeline = dynamic(
+  () => import("@/components/dashboard/validator-jailing-timeline").then((m) => m.ValidatorJailingTimeline),
+  { ssr: false },
+);
+const RewardHistoryChart = dynamic(
+  () => import("@/components/charts/reward-history-chart").then((m) => m.RewardHistoryChart),
+  { ssr: false, loading: () => <Skeleton className="h-64 w-full rounded-lg bg-deep-iris/20" /> },
+);
 import { getValidatorStatusInfo } from "@/lib/status";
 import {
   formatTokens,
@@ -29,7 +41,8 @@ import {
 } from "@/lib/formatters";
 import { formatDate, timeAgo } from "@/lib/time";
 import { CHART_COLORS } from "@/lib/constants";
-import { ArrowLeft, ShieldAlert, Calendar, Trophy, Users, Vote, Activity } from "lucide-react";
+import { useValidatorRewards } from "@/hooks/use-validator-yaci";
+import { ArrowLeft, ShieldAlert, Calendar, Trophy, Users, Vote, Activity, Coins } from "lucide-react";
 import { HelpTooltip } from "./help-tooltip";
 import { helpContent } from "@/lib/help-content";
 import { subDays } from "date-fns";
@@ -52,6 +65,7 @@ export function ValidatorDetail({ validatorId }: ValidatorDetailProps) {
     [range]
   );
 
+  const { data: rewardsData, error: rewardsError } = useValidatorRewards(validatorId);
   const { data, error, isLoading, mutate } = useValidatorDetail(validatorId, {
     from,
     limit: 500,
@@ -266,6 +280,39 @@ export function ValidatorDetail({ validatorId }: ValidatorDetailProps) {
 
       {/* Compute performance */}
       <ComputeSection validatorId={validatorId} />
+
+      {/* Signing & Jailing (Yaci) */}
+      <div className="grid gap-4 lg:grid-cols-2">
+        <ValidatorSigningStats validatorId={validatorId} />
+        <ValidatorJailingTimeline validatorId={validatorId} />
+      </div>
+
+      {/* Reward History (Yaci) */}
+      {rewardsError ? (
+        <Card className="border-slate-DEFAULT/20 bg-midnight-plum">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-sm font-medium text-dusty-lavender/70">
+              <Coins className="size-4" />
+              Reward History
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-xs text-dusty-lavender/50">Reward data temporarily unavailable</p>
+          </CardContent>
+        </Card>
+      ) : rewardsData && rewardsData.length > 0 ? (
+        <Card className="border-slate-DEFAULT/20 bg-midnight-plum">
+          <CardHeader className="pb-2">
+            <CardTitle className="flex items-center gap-2 text-sm font-medium text-dusty-lavender/70">
+              <Coins className="size-4" />
+              Reward History (Last {rewardsData.length} blocks)
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <RewardHistoryChart data={rewardsData} />
+          </CardContent>
+        </Card>
+      ) : null}
 
       {/* Related links */}
       <div className="flex flex-wrap gap-2">

--- a/src/components/dashboard/validator-jailing-timeline.tsx
+++ b/src/components/dashboard/validator-jailing-timeline.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useValidatorJailing } from "@/hooks/use-validator-yaci";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ShieldAlert } from "lucide-react";
+import { timeAgo } from "@/lib/time";
+import { formatNumber } from "@/lib/formatters";
+
+interface ValidatorJailingTimelineProps {
+  validatorId: string;
+}
+
+export function ValidatorJailingTimeline({ validatorId }: ValidatorJailingTimelineProps) {
+  const { data: events, error } = useValidatorJailing(validatorId);
+
+  // Upstream error → show degraded state
+  if (error) {
+    return (
+      <Card className="border-slate-DEFAULT/20 bg-midnight-plum">
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium text-dusty-lavender/70">
+            <ShieldAlert className="size-4" />
+            Jailing History
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-xs text-dusty-lavender/50">Jailing data temporarily unavailable</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!events || events.length === 0) return null;
+
+  return (
+    <Card className="border-slate-DEFAULT/20 bg-midnight-plum">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium text-dusty-lavender/70">
+          <ShieldAlert className="size-4" />
+          Jailing History ({events.length})
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          {events.map((event) => (
+            <div
+              key={event.id}
+              className="flex items-center justify-between rounded-lg border border-rose-DEFAULT/10 bg-rose-dark/5 px-3 py-2"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="text-xs font-medium text-mist">
+                  Block #{formatNumber(event.height)}
+                </p>
+                <p className="text-[10px] text-dusty-lavender/50">
+                  {event.current_block_flag} &middot; {timeAgo(event.detected_at)}
+                </p>
+              </div>
+              <ShieldAlert className="size-3.5 shrink-0 text-rose-DEFAULT/60" />
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/validator-signing-stats.tsx
+++ b/src/components/dashboard/validator-signing-stats.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useValidatorSigning } from "@/hooks/use-validator-yaci";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Activity } from "lucide-react";
+import { formatNumber } from "@/lib/formatters";
+
+interface ValidatorSigningStatsProps {
+  validatorId: string;
+}
+
+function getSigningColor(pct: number): string {
+  if (pct >= 99) return "text-teal-DEFAULT";
+  if (pct >= 95) return "text-amber-DEFAULT";
+  return "text-rose-DEFAULT";
+}
+
+function getSigningBg(pct: number): string {
+  if (pct >= 99) return "bg-teal-DEFAULT/10 border-teal-DEFAULT/20";
+  if (pct >= 95) return "bg-amber-DEFAULT/10 border-amber-DEFAULT/20";
+  return "bg-rose-DEFAULT/10 border-rose-DEFAULT/20";
+}
+
+export function ValidatorSigningStats({ validatorId }: ValidatorSigningStatsProps) {
+  const { data: stats, error } = useValidatorSigning(validatorId);
+
+  // Upstream error → show degraded state so it doesn't look like missing data
+  if (error) {
+    return (
+      <Card className="border-slate-DEFAULT/20 bg-midnight-plum">
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-sm font-medium text-dusty-lavender/70">
+            <Activity className="size-4" />
+            Signing Performance
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-xs text-dusty-lavender/50">Signing data temporarily unavailable</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!stats) return null;
+
+  const pct = stats.signing_percentage;
+
+  return (
+    <Card className="border-slate-DEFAULT/20 bg-midnight-plum">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium text-dusty-lavender/70">
+          <Activity className="size-4" />
+          Signing Performance
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className={`mb-3 rounded-lg border p-3 ${getSigningBg(pct)}`}>
+          <p className={`text-center font-mono text-3xl font-bold ${getSigningColor(pct)}`}>
+            {pct.toFixed(2)}%
+          </p>
+          <p className="mt-1 text-center text-xs text-dusty-lavender/50">
+            signing rate
+          </p>
+        </div>
+        <div className="grid grid-cols-3 gap-2 text-center">
+          <div>
+            <p className="font-mono text-sm font-medium text-mist">
+              {formatNumber(stats.blocks_signed)}
+            </p>
+            <p className="text-[10px] text-dusty-lavender/50">signed</p>
+          </div>
+          <div>
+            <p className="font-mono text-sm font-medium text-rose-DEFAULT">
+              {formatNumber(stats.blocks_missed)}
+            </p>
+            <p className="text-[10px] text-dusty-lavender/50">missed</p>
+          </div>
+          <div>
+            <p className="font-mono text-sm font-medium text-dusty-lavender">
+              {formatNumber(stats.total_blocks)}
+            </p>
+            <p className="text-[10px] text-dusty-lavender/50">total</p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/use-network-analytics.ts
+++ b/src/hooks/use-network-analytics.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import useSWR from "swr";
+import { pollingSwrConfig } from "./use-api";
+import type {
+  YaciDailyTxStats,
+  YaciTxSuccessRate,
+  YaciMessageTypeStat,
+  YaciGasDistribution,
+  YaciFeeRevenue,
+  YaciBlockMetric,
+  YaciNetworkOverview,
+  YaciDailyRewards,
+} from "@/types";
+
+export function useDailyTxStats() {
+  return useSWR<YaciDailyTxStats[]>("/api/stats/tx-daily", pollingSwrConfig);
+}
+
+export function useTxSuccessRate() {
+  return useSWR<YaciTxSuccessRate>("/api/stats/tx-success-rate", pollingSwrConfig);
+}
+
+export function useMessageTypeStats() {
+  return useSWR<YaciMessageTypeStat[]>("/api/stats/message-types", pollingSwrConfig);
+}
+
+export function useGasDistribution() {
+  return useSWR<YaciGasDistribution[]>("/api/stats/gas-distribution", pollingSwrConfig);
+}
+
+export function useFeeRevenue() {
+  return useSWR<YaciFeeRevenue>("/api/stats/fee-revenue", pollingSwrConfig);
+}
+
+export function useBlockMetrics() {
+  return useSWR<YaciBlockMetric[]>("/api/stats/block-metrics", pollingSwrConfig);
+}
+
+export function useYaciNetworkOverview() {
+  return useSWR<YaciNetworkOverview>("/api/stats/network-overview", pollingSwrConfig);
+}
+
+export function useDailyRewards() {
+  return useSWR<YaciDailyRewards[]>("/api/stats/daily-rewards", pollingSwrConfig);
+}

--- a/src/hooks/use-validator-yaci.ts
+++ b/src/hooks/use-validator-yaci.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import useSWR from "swr";
+import { pollingSwrConfig } from "./use-api";
+import type {
+  YaciJailingEvent,
+  YaciValidatorSigningStats,
+  YaciValidatorReward,
+} from "@/types";
+
+export function useValidatorJailing(validatorId: string | null) {
+  const url = validatorId ? `/api/validators/${validatorId}/jailing` : null;
+  return useSWR<YaciJailingEvent[]>(url, pollingSwrConfig);
+}
+
+export function useValidatorSigning(validatorId: string | null) {
+  const url = validatorId ? `/api/validators/${validatorId}/signing` : null;
+  return useSWR<YaciValidatorSigningStats>(url, pollingSwrConfig);
+}
+
+export function useValidatorRewards(validatorId: string | null) {
+  const url = validatorId ? `/api/validators/${validatorId}/rewards` : null;
+  return useSWR<YaciValidatorReward[]>(url, pollingSwrConfig);
+}

--- a/src/lib/help-content.ts
+++ b/src/lib/help-content.ts
@@ -145,6 +145,13 @@ export const helpContent = {
       bondedRatio: "Percentage of total token supply currently staked. Higher ratio = more network security.",
       blockHeight: "The latest confirmed block number on the chain.",
       avgBlockTime: "Average time between consecutive blocks. Indicates chain speed.",
+      txSuccessRate: "Percentage of transactions that completed successfully across the network lifetime.",
+      feeRevenue: "Total transaction fees collected by the network across all blocks.",
+      gasDistribution: "Distribution of gas usage across transactions. Shows the most common gas consumption ranges.",
+      messageTypes: "Breakdown of transaction types on the network. Shows which operations are most common.",
+      blockTime: "Time between consecutive blocks. Spikes may indicate network congestion or validator issues.",
+      dailyTxVolume: "Number of transactions processed each day over the last 30 days.",
+      dailyRewards: "Total validator rewards and commissions distributed each day across the network.",
     },
   },
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -417,3 +417,95 @@ export interface DelegationSnapshotItem {
   churnRate: number;
   timestamp: string;
 }
+
+// ── Yaci Explorer Types ──
+
+export interface YaciDailyTxStats {
+  date: string;
+  total_txs: number;
+  successful_txs: number;
+  failed_txs: number;
+  unique_senders: number;
+}
+
+export interface YaciTxSuccessRate {
+  total: number;
+  successful: number;
+  failed: number;
+  success_rate_percent: number;
+}
+
+export interface YaciMessageTypeStat {
+  message_type: string;
+  count: number;
+  percentage: number;
+}
+
+export interface YaciNetworkOverview {
+  total_validators: number;
+  active_validators: number;
+  jailed_validators: number;
+  total_bonded_tokens: string;
+  total_rewards_24h: number;
+  total_commission_24h: number;
+  avg_block_time: number;
+  total_transactions: number;
+  unique_addresses: number;
+  max_validators: number;
+}
+
+export interface YaciBlockMetric {
+  height: number;
+  block_time: string | null;
+  tx_count: number;
+  gas_used: number;
+  total_rewards: string;
+  total_commission: string;
+  validator_count: number;
+  created_at: string;
+}
+
+export interface YaciGasDistribution {
+  gas_range: string;
+  count: number;
+}
+
+export interface YaciFeeRevenue {
+  denom: string;
+  total_amount: string;
+}
+
+export interface YaciDailyRewards {
+  date: string;
+  total_rewards: string;
+  total_commission: string;
+}
+
+export interface YaciJailingEvent {
+  id: number;
+  validator_address: string;
+  operator_address: string | null;
+  height: number;
+  detected_at: string;
+  prev_block_flag: string;
+  current_block_flag: string;
+}
+
+export interface YaciValidatorSigningStats {
+  consensus_address: string;
+  operator_address: string;
+  total_blocks: number;
+  blocks_signed: number;
+  blocks_missed: number;
+  signing_percentage: number;
+  last_height: number;
+}
+
+export interface YaciValidatorReward {
+  id: number;
+  height: number;
+  validator_address: string;
+  rewards: string;
+  commission: string;
+  created_at: string;
+}

--- a/tests/unit/api/block-metrics.test.ts
+++ b/tests/unit/api/block-metrics.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-helpers", async () => {
+  const { NextResponse } = await import("next/server");
+  return {
+    withRateLimit: vi.fn(() => ({ headers: { "X-RateLimit-Limit": "60" } })),
+    jsonResponse: vi.fn((data: unknown, headers: Record<string, string>, status = 200) =>
+      NextResponse.json(data, { status, headers }),
+    ),
+  };
+});
+
+vi.mock("@/lib/yaci", () => ({
+  fetchYaci: vi.fn(),
+}));
+
+import { fetchYaci } from "@/lib/yaci";
+
+describe("GET /api/stats/block-metrics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns block metrics array", async () => {
+    const mockData = [
+      { height: 482001, block_time: "2026-02-25T06:09:50Z", tx_count: 5, gas_used: 1000, total_rewards: "100", total_commission: "10", validator_count: 91, created_at: "2026-02-25T06:10:00Z" },
+      { height: 482000, block_time: "2026-02-25T06:09:45Z", tx_count: 3, gas_used: 800, total_rewards: "90", total_commission: "9", validator_count: 91, created_at: "2026-02-25T06:09:55Z" },
+    ];
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: mockData });
+
+    const { GET } = await import("@/app/api/stats/block-metrics/route");
+    const req = new NextRequest("http://localhost/api/stats/block-metrics");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveLength(2);
+    expect(body[0].height).toBe(482001);
+  });
+
+  it("returns 502 when yaci is unreachable", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: false, error: "http" });
+
+    const { GET } = await import("@/app/api/stats/block-metrics/route");
+    const req = new NextRequest("http://localhost/api/stats/block-metrics");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toMatch(/unavailable/i);
+  });
+
+  it("returns empty array when yaci returns no data", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: [] });
+
+    const { GET } = await import("@/app/api/stats/block-metrics/route");
+    const req = new NextRequest("http://localhost/api/stats/block-metrics");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual([]);
+  });
+});

--- a/tests/unit/api/daily-rewards.test.ts
+++ b/tests/unit/api/daily-rewards.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-helpers", async () => {
+  const { NextResponse } = await import("next/server");
+  return {
+    withRateLimit: vi.fn(() => ({ headers: { "X-RateLimit-Limit": "60" } })),
+    jsonResponse: vi.fn((data: unknown, headers: Record<string, string>, status = 200) =>
+      NextResponse.json(data, { status, headers }),
+    ),
+  };
+});
+
+vi.mock("@/lib/yaci", () => ({
+  fetchYaci: vi.fn(),
+}));
+
+import { fetchYaci } from "@/lib/yaci";
+
+describe("GET /api/stats/daily-rewards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns daily rewards data", async () => {
+    const mockData = [
+      { date: "2026-02-10", total_rewards: "337116305571413198954773.484", total_commission: "34168211259089522314152.485" },
+      { date: "2026-02-09", total_rewards: "320000000000000000000000.000", total_commission: "32000000000000000000000.000" },
+    ];
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: mockData });
+
+    const { GET } = await import("@/app/api/stats/daily-rewards/route");
+    const req = new NextRequest("http://localhost/api/stats/daily-rewards");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveLength(2);
+    expect(body[0].date).toBe("2026-02-10");
+  });
+
+  it("returns 502 when yaci is unreachable", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: false, error: "timeout" });
+
+    const { GET } = await import("@/app/api/stats/daily-rewards/route");
+    const req = new NextRequest("http://localhost/api/stats/daily-rewards");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toMatch(/unavailable/i);
+  });
+
+  it("returns empty array when yaci returns no data", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: [] });
+
+    const { GET } = await import("@/app/api/stats/daily-rewards/route");
+    const req = new NextRequest("http://localhost/api/stats/daily-rewards");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual([]);
+  });
+});

--- a/tests/unit/api/fee-revenue.test.ts
+++ b/tests/unit/api/fee-revenue.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-helpers", async () => {
+  const { NextResponse } = await import("next/server");
+  return {
+    withRateLimit: vi.fn(() => ({ headers: { "X-RateLimit-Limit": "60" } })),
+    jsonResponse: vi.fn((data: unknown, headers: Record<string, string>, status = 200) =>
+      NextResponse.json(data, { status, headers }),
+    ),
+  };
+});
+
+vi.mock("@/lib/yaci", () => ({
+  fetchYaci: vi.fn(),
+}));
+
+import { fetchYaci } from "@/lib/yaci";
+
+describe("GET /api/stats/fee-revenue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns fee revenue from first element", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({
+      ok: true,
+      data: [{ denom: "arai", total_amount: "4540778090507873195492" }],
+    });
+
+    const { GET } = await import("@/app/api/stats/fee-revenue/route");
+    const req = new NextRequest("http://localhost/api/stats/fee-revenue");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.denom).toBe("arai");
+    expect(body.total_amount).toBe("4540778090507873195492");
+  });
+
+  it("returns 502 when yaci is unreachable", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: false, error: "network" });
+
+    const { GET } = await import("@/app/api/stats/fee-revenue/route");
+    const req = new NextRequest("http://localhost/api/stats/fee-revenue");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toMatch(/unavailable/i);
+  });
+
+  it("returns null when yaci returns empty array", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: [] });
+
+    const { GET } = await import("@/app/api/stats/fee-revenue/route");
+    const req = new NextRequest("http://localhost/api/stats/fee-revenue");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toBeNull();
+  });
+});

--- a/tests/unit/api/gas-distribution.test.ts
+++ b/tests/unit/api/gas-distribution.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-helpers", async () => {
+  const { NextResponse } = await import("next/server");
+  return {
+    withRateLimit: vi.fn(() => ({ headers: { "X-RateLimit-Limit": "60" } })),
+    jsonResponse: vi.fn((data: unknown, headers: Record<string, string>, status = 200) =>
+      NextResponse.json(data, { status, headers }),
+    ),
+  };
+});
+
+vi.mock("@/lib/yaci", () => ({
+  fetchYaci: vi.fn(),
+}));
+
+import { fetchYaci } from "@/lib/yaci";
+
+describe("GET /api/stats/gas-distribution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns gas distribution data", async () => {
+    const mockData = [
+      { gas_range: "0-100k", count: 119353 },
+      { gas_range: "100k-200k", count: 45000 },
+    ];
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: mockData });
+
+    const { GET } = await import("@/app/api/stats/gas-distribution/route");
+    const req = new NextRequest("http://localhost/api/stats/gas-distribution");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveLength(2);
+    expect(body[0].gas_range).toBe("0-100k");
+  });
+
+  it("returns 502 when yaci is unreachable", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: false, error: "timeout" });
+
+    const { GET } = await import("@/app/api/stats/gas-distribution/route");
+    const req = new NextRequest("http://localhost/api/stats/gas-distribution");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toMatch(/unavailable/i);
+  });
+
+  it("returns empty array when yaci returns no data", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: [] });
+
+    const { GET } = await import("@/app/api/stats/gas-distribution/route");
+    const req = new NextRequest("http://localhost/api/stats/gas-distribution");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual([]);
+  });
+});

--- a/tests/unit/api/message-types.test.ts
+++ b/tests/unit/api/message-types.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-helpers", async () => {
+  const { NextResponse } = await import("next/server");
+  return {
+    withRateLimit: vi.fn(() => ({ headers: { "X-RateLimit-Limit": "60" } })),
+    jsonResponse: vi.fn((data: unknown, headers: Record<string, string>, status = 200) =>
+      NextResponse.json(data, { status, headers }),
+    ),
+  };
+});
+
+vi.mock("@/lib/yaci", () => ({
+  fetchYaci: vi.fn(),
+}));
+
+import { fetchYaci } from "@/lib/yaci";
+
+describe("GET /api/stats/message-types", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns message type stats", async () => {
+    const mockData = [
+      { message_type: "/cosmos.staking.v1beta1.MsgDelegate", count: 1000, percentage: 50 },
+      { message_type: "/cosmos.bank.v1beta1.MsgSend", count: 500, percentage: 25 },
+    ];
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: mockData });
+
+    const { GET } = await import("@/app/api/stats/message-types/route");
+    const req = new NextRequest("http://localhost/api/stats/message-types");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveLength(2);
+    expect(body[0].count).toBe(1000);
+  });
+
+  it("returns 502 when yaci is unreachable", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: false, error: "http" });
+
+    const { GET } = await import("@/app/api/stats/message-types/route");
+    const req = new NextRequest("http://localhost/api/stats/message-types");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toMatch(/unavailable/i);
+  });
+
+  it("returns empty array when yaci returns no data", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: [] });
+
+    const { GET } = await import("@/app/api/stats/message-types/route");
+    const req = new NextRequest("http://localhost/api/stats/message-types");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual([]);
+  });
+});

--- a/tests/unit/api/network-overview.test.ts
+++ b/tests/unit/api/network-overview.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-helpers", async () => {
+  const { NextResponse } = await import("next/server");
+  return {
+    withRateLimit: vi.fn(() => ({ headers: { "X-RateLimit-Limit": "60" } })),
+    jsonResponse: vi.fn((data: unknown, headers: Record<string, string>, status = 200) =>
+      NextResponse.json(data, { status, headers }),
+    ),
+  };
+});
+
+vi.mock("@/lib/yaci", () => ({
+  fetchYaci: vi.fn(),
+}));
+
+import { fetchYaci } from "@/lib/yaci";
+
+describe("GET /api/stats/network-overview", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns network overview from first element", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({
+      ok: true,
+      data: [{
+        total_validators: 438,
+        active_validators: 91,
+        jailed_validators: 103,
+        total_bonded_tokens: 34980320554247513499346467,
+        total_rewards_24h: 295530.78,
+        total_commission_24h: 29932.50,
+        avg_block_time: 5.11,
+        total_transactions: 40563,
+        unique_addresses: 3153,
+        max_validators: 100,
+      }],
+    });
+
+    const { GET } = await import("@/app/api/stats/network-overview/route");
+    const req = new NextRequest("http://localhost/api/stats/network-overview");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.total_validators).toBe(438);
+    expect(body.active_validators).toBe(91);
+    expect(body.avg_block_time).toBe(5.11);
+  });
+
+  it("returns 502 when yaci is unreachable", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: false, error: "timeout" });
+
+    const { GET } = await import("@/app/api/stats/network-overview/route");
+    const req = new NextRequest("http://localhost/api/stats/network-overview");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toMatch(/unavailable/i);
+  });
+
+  it("returns null when yaci returns empty array", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: [] });
+
+    const { GET } = await import("@/app/api/stats/network-overview/route");
+    const req = new NextRequest("http://localhost/api/stats/network-overview");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toBeNull();
+  });
+});

--- a/tests/unit/api/tx-daily-stats.test.ts
+++ b/tests/unit/api/tx-daily-stats.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-helpers", async () => {
+  const { NextResponse } = await import("next/server");
+  return {
+    withRateLimit: vi.fn(() => ({ headers: { "X-RateLimit-Limit": "60" } })),
+    jsonResponse: vi.fn((data: unknown, headers: Record<string, string>, status = 200) =>
+      NextResponse.json(data, { status, headers }),
+    ),
+  };
+});
+
+vi.mock("@/lib/yaci", () => ({
+  fetchYaci: vi.fn(),
+}));
+
+import { fetchYaci } from "@/lib/yaci";
+
+describe("GET /api/stats/tx-daily", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns daily tx stats array", async () => {
+    const mockData = [
+      { date: "2026-04-01", total_txs: 216330, successful_txs: 216250, failed_txs: 80, unique_senders: 0 },
+      { date: "2026-03-31", total_txs: 200000, successful_txs: 199900, failed_txs: 100, unique_senders: 0 },
+    ];
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: mockData });
+
+    const { GET } = await import("@/app/api/stats/tx-daily/route");
+    const req = new NextRequest("http://localhost/api/stats/tx-daily");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveLength(2);
+    expect(body[0].total_txs).toBe(216330);
+  });
+
+  it("returns 502 when yaci is unreachable", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: false, error: "timeout" });
+
+    const { GET } = await import("@/app/api/stats/tx-daily/route");
+    const req = new NextRequest("http://localhost/api/stats/tx-daily");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toMatch(/unavailable/i);
+  });
+
+  it("returns empty array when yaci returns no data", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: [] });
+
+    const { GET } = await import("@/app/api/stats/tx-daily/route");
+    const req = new NextRequest("http://localhost/api/stats/tx-daily");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual([]);
+  });
+});

--- a/tests/unit/api/tx-success-rate.test.ts
+++ b/tests/unit/api/tx-success-rate.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-helpers", async () => {
+  const { NextResponse } = await import("next/server");
+  return {
+    withRateLimit: vi.fn(() => ({ headers: { "X-RateLimit-Limit": "60" } })),
+    jsonResponse: vi.fn((data: unknown, headers: Record<string, string>, status = 200) =>
+      NextResponse.json(data, { status, headers }),
+    ),
+  };
+});
+
+vi.mock("@/lib/yaci", () => ({
+  fetchYaci: vi.fn(),
+}));
+
+import { fetchYaci } from "@/lib/yaci";
+
+describe("GET /api/stats/tx-success-rate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns success rate from first element", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({
+      ok: true,
+      data: [{ total: 4779945, successful: 4746228, failed: 33717, success_rate_percent: 99.29 }],
+    });
+
+    const { GET } = await import("@/app/api/stats/tx-success-rate/route");
+    const req = new NextRequest("http://localhost/api/stats/tx-success-rate");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success_rate_percent).toBe(99.29);
+    expect(body.total).toBe(4779945);
+  });
+
+  it("returns 502 when yaci is unreachable", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: false, error: "network" });
+
+    const { GET } = await import("@/app/api/stats/tx-success-rate/route");
+    const req = new NextRequest("http://localhost/api/stats/tx-success-rate");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toMatch(/unavailable/i);
+  });
+
+  it("returns null when yaci returns empty array", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: [] });
+
+    const { GET } = await import("@/app/api/stats/tx-success-rate/route");
+    const req = new NextRequest("http://localhost/api/stats/tx-success-rate");
+    const res = await GET(req);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toBeNull();
+  });
+});

--- a/tests/unit/api/validator-jailing.test.ts
+++ b/tests/unit/api/validator-jailing.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-helpers", async () => {
+  const { NextResponse } = await import("next/server");
+  return {
+    withRateLimit: vi.fn(() => ({ headers: { "X-RateLimit-Limit": "60" } })),
+    jsonResponse: vi.fn((data: unknown, headers: Record<string, string>, status = 200) =>
+      NextResponse.json(data, { status, headers }),
+    ),
+  };
+});
+
+vi.mock("@/lib/yaci", () => ({
+  fetchYaci: vi.fn(),
+}));
+
+import { fetchYaci } from "@/lib/yaci";
+
+describe("GET /api/validators/[id]/jailing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves consensus address then fetches jailing events", async () => {
+    vi.mocked(fetchYaci)
+      // First call: validator lookup to get consensus address
+      .mockResolvedValueOnce({
+        ok: true,
+        data: [{ operator_address: "raivaloper1abc", consensus_address: "raivalcons1xyz" }],
+      })
+      // Second call: jailing events filtered by consensus address
+      .mockResolvedValueOnce({
+        ok: true,
+        data: [
+          { id: 1, validator_address: "raivalcons1xyz", operator_address: null, height: 144500, detected_at: "2026-02-04T18:54:47Z", prev_block_flag: "FINALIZE_BLOCK_EVENT", current_block_flag: "liveness" },
+        ],
+      });
+
+    const { GET } = await import("@/app/api/validators/[id]/jailing/route");
+    const req = new NextRequest("http://localhost/api/validators/raivaloper1abc/jailing");
+    const res = await GET(req, { params: Promise.resolve({ id: "raivaloper1abc" }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveLength(1);
+    expect(body[0].height).toBe(144500);
+
+    // Assert the correct URLs were called
+    expect(vi.mocked(fetchYaci)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(fetchYaci).mock.calls[0][0]).toContain("/validators?operator_address=eq.raivaloper1abc");
+    expect(vi.mocked(fetchYaci).mock.calls[1][0]).toContain("/jailing_events?validator_address=eq.raivalcons1xyz");
+  });
+
+  it("returns 502 when validator lookup fails", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: false, error: "timeout" });
+
+    const { GET } = await import("@/app/api/validators/[id]/jailing/route");
+    const req = new NextRequest("http://localhost/api/validators/raivaloper1abc/jailing");
+    const res = await GET(req, { params: Promise.resolve({ id: "raivaloper1abc" }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toMatch(/unavailable/i);
+  });
+
+  it("returns 502 when jailing events fetch fails after successful lookup", async () => {
+    vi.mocked(fetchYaci)
+      .mockResolvedValueOnce({
+        ok: true,
+        data: [{ operator_address: "raivaloper1abc", consensus_address: "raivalcons1xyz" }],
+      })
+      .mockResolvedValueOnce({ ok: false, error: "timeout" });
+
+    const { GET } = await import("@/app/api/validators/[id]/jailing/route");
+    const req = new NextRequest("http://localhost/api/validators/raivaloper1abc/jailing");
+    const res = await GET(req, { params: Promise.resolve({ id: "raivaloper1abc" }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toMatch(/unavailable/i);
+    expect(vi.mocked(fetchYaci)).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns empty array when validator has no consensus address", async () => {
+    vi.mocked(fetchYaci).mockResolvedValueOnce({
+      ok: true,
+      data: [{ operator_address: "raivaloper1abc", consensus_address: null }],
+    });
+
+    const { GET } = await import("@/app/api/validators/[id]/jailing/route");
+    const req = new NextRequest("http://localhost/api/validators/raivaloper1abc/jailing");
+    const res = await GET(req, { params: Promise.resolve({ id: "raivaloper1abc" }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual([]);
+    // Should only call validator lookup, not jailing events
+    expect(vi.mocked(fetchYaci)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/api/validator-rewards.test.ts
+++ b/tests/unit/api/validator-rewards.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-helpers", async () => {
+  const { NextResponse } = await import("next/server");
+  return {
+    withRateLimit: vi.fn(() => ({ headers: { "X-RateLimit-Limit": "60" } })),
+    jsonResponse: vi.fn((data: unknown, headers: Record<string, string>, status = 200) =>
+      NextResponse.json(data, { status, headers }),
+    ),
+  };
+});
+
+vi.mock("@/lib/yaci", () => ({
+  fetchYaci: vi.fn(),
+}));
+
+import { fetchYaci } from "@/lib/yaci";
+
+describe("GET /api/validators/[id]/rewards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns reward history and uses correct URL with validator_address filter", async () => {
+    const mockData = [
+      { id: 1, height: 235764, validator_address: "raivaloper1abc", rewards: "1357261091346037.479", commission: "135726109134603.748", created_at: "2026-02-10T16:14:37Z" },
+    ];
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: mockData });
+
+    const { GET } = await import("@/app/api/validators/[id]/rewards/route");
+    const req = new NextRequest("http://localhost/api/validators/raivaloper1abc/rewards");
+    const res = await GET(req, { params: Promise.resolve({ id: "raivaloper1abc" }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toHaveLength(1);
+    expect(body[0].height).toBe(235764);
+
+    // Assert the correct URL was called with validator_address filter
+    expect(vi.mocked(fetchYaci)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fetchYaci).mock.calls[0][0]).toBe(
+      "/validator_rewards?validator_address=eq.raivaloper1abc&order=height.desc&limit=100",
+    );
+  });
+
+  it("returns 502 when yaci is unreachable", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: false, error: "http" });
+
+    const { GET } = await import("@/app/api/validators/[id]/rewards/route");
+    const req = new NextRequest("http://localhost/api/validators/raivaloper1abc/rewards");
+    const res = await GET(req, { params: Promise.resolve({ id: "raivaloper1abc" }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toMatch(/unavailable/i);
+  });
+
+  it("returns empty array when no rewards", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: [] });
+
+    const { GET } = await import("@/app/api/validators/[id]/rewards/route");
+    const req = new NextRequest("http://localhost/api/validators/raivaloper1abc/rewards");
+    const res = await GET(req, { params: Promise.resolve({ id: "raivaloper1abc" }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual([]);
+  });
+});

--- a/tests/unit/api/validator-signing.test.ts
+++ b/tests/unit/api/validator-signing.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/api-helpers", async () => {
+  const { NextResponse } = await import("next/server");
+  return {
+    withRateLimit: vi.fn(() => ({ headers: { "X-RateLimit-Limit": "60" } })),
+    jsonResponse: vi.fn((data: unknown, headers: Record<string, string>, status = 200) =>
+      NextResponse.json(data, { status, headers }),
+    ),
+  };
+});
+
+vi.mock("@/lib/yaci", () => ({
+  fetchYaci: vi.fn(),
+}));
+
+import { fetchYaci } from "@/lib/yaci";
+
+describe("GET /api/validators/[id]/signing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns signing stats and uses correct URL with operator_address filter", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({
+      ok: true,
+      data: [{
+        consensus_address: "00787E83EEC225760B28138437622B2D0ADE32DD",
+        operator_address: "raivaloper1abc",
+        total_blocks: 10000,
+        blocks_signed: 9944,
+        blocks_missed: 56,
+        signing_percentage: 99.44,
+        last_height: 926121,
+      }],
+    });
+
+    const { GET } = await import("@/app/api/validators/[id]/signing/route");
+    const req = new NextRequest("http://localhost/api/validators/raivaloper1abc/signing");
+    const res = await GET(req, { params: Promise.resolve({ id: "raivaloper1abc" }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.signing_percentage).toBe(99.44);
+    expect(body.blocks_signed).toBe(9944);
+
+    // Assert the correct URL was called with operator_address filter
+    expect(vi.mocked(fetchYaci)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(fetchYaci).mock.calls[0][0]).toBe(
+      "/mv_validator_signing_stats?operator_address=eq.raivaloper1abc",
+    );
+  });
+
+  it("returns 502 when yaci is unreachable", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: false, error: "network" });
+
+    const { GET } = await import("@/app/api/validators/[id]/signing/route");
+    const req = new NextRequest("http://localhost/api/validators/raivaloper1abc/signing");
+    const res = await GET(req, { params: Promise.resolve({ id: "raivaloper1abc" }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.error).toMatch(/unavailable/i);
+  });
+
+  it("returns null when yaci returns empty array", async () => {
+    vi.mocked(fetchYaci).mockResolvedValue({ ok: true, data: [] });
+
+    const { GET } = await import("@/app/api/validators/[id]/signing/route");
+    const req = new NextRequest("http://localhost/api/validators/raivaloper1abc/signing");
+    const res = await GET(req, { params: Promise.resolve({ id: "raivaloper1abc" }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toBeNull();
+  });
+});

--- a/tests/unit/lib/help-content.test.ts
+++ b/tests/unit/lib/help-content.test.ts
@@ -94,7 +94,7 @@ describe("helpContent", () => {
     expect(Object.keys(helpContent.delegations.types).length).toBe(4);
   });
 
-  it("network.fields has 3 keys", () => {
-    expect(Object.keys(helpContent.network.fields).length).toBe(3);
+  it("network.fields has 10 keys", () => {
+    expect(Object.keys(helpContent.network.fields).length).toBe(10);
   });
 });


### PR DESCRIPTION
## Summary

- **Delegation page**: Client-side pagination (10/page) with safe page clamping + 2-column layout redesign (Flow | List side-by-side, WhaleMovements full-width below)
- **Network analytics**: 8 Yaci API proxy routes + NetworkActivity section with TX success rate, fee revenue, daily TX volume chart, message type breakdown, gas distribution, block time trend, daily rewards & commission
- **Overview enhancement**: 3 new StatCards (Total Transactions, Unique Addresses, Avg Block Time) from Yaci network overview
- **Validator enrichment**: Signing performance (color-coded thresholds), jailing history timeline (two-step consensus address resolve), reward history chart — all with degraded error state on upstream failure

### Stats
| | New | Modified | Tests |
|---|---|---|---|
| API routes | 11 | 0 | 11 files (37 tests) |
| Charts | 6 | 0 | — |
| Components | 3 | 5 | — |
| Hooks | 2 | 0 | — |
| Types/Help | 0 | 2 | 1 updated |
| **Total** | **22** | **7** | **12 files** |

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 1309/1309 passed (139 files)
- [x] `npm run build` — exit 0
- [ ] Manual: Delegation layout + pagination on `/dashboard/delegations`
- [ ] Manual: Network analytics charts on `/dashboard/network`
- [ ] Manual: Overview Yaci stats on `/dashboard`
- [ ] Manual: Validator signing/jailing/rewards on `/dashboard/validators/[id]`
- [ ] Manual: Yaci API down → all new sections gracefully degrade