### PR TITLE
fix(security): close PR #115 audit backlog

### DIFF
--- a/src/app/api/validators/[id]/jailing/route.ts
+++ b/src/app/api/validators/[id]/jailing/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { withRateLimit, jsonResponse } from "@/lib/api-helpers";
 import { fetchYaci } from "@/lib/yaci";
+import { isValidValoperAddress } from "@/lib/validation";
 import type { YaciJailingEvent } from "@/types";
 
 interface YaciValidator {
@@ -16,6 +17,9 @@ export async function GET(
   if ("response" in rl) return rl.response;
 
   const { id } = await params;
+  if (!isValidValoperAddress(id)) {
+    return jsonResponse({ error: "Invalid validator address" }, rl.headers, 400);
+  }
   const encoded = encodeURIComponent(id);
 
   // Jailing events use validator_address (consensus format, e.g. raivalcons1...).

--- a/src/app/api/validators/[id]/rewards/route.ts
+++ b/src/app/api/validators/[id]/rewards/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { withRateLimit, jsonResponse } from "@/lib/api-helpers";
 import { fetchYaci } from "@/lib/yaci";
+import { isValidValoperAddress } from "@/lib/validation";
 import type { YaciValidatorReward } from "@/types";
 
 export async function GET(
@@ -11,6 +12,9 @@ export async function GET(
   if ("response" in rl) return rl.response;
 
   const { id } = await params;
+  if (!isValidValoperAddress(id)) {
+    return jsonResponse({ error: "Invalid validator address" }, rl.headers, 400);
+  }
   const encoded = encodeURIComponent(id);
 
   const result = await fetchYaci<YaciValidatorReward[]>(

--- a/src/app/api/validators/[id]/signing/route.ts
+++ b/src/app/api/validators/[id]/signing/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { withRateLimit, jsonResponse } from "@/lib/api-helpers";
 import { fetchYaci } from "@/lib/yaci";
+import { isValidValoperAddress } from "@/lib/validation";
 import type { YaciValidatorSigningStats } from "@/types";
 
 export async function GET(
@@ -11,6 +12,9 @@ export async function GET(
   if ("response" in rl) return rl.response;
 
   const { id } = await params;
+  if (!isValidValoperAddress(id)) {
+    return jsonResponse({ error: "Invalid validator address" }, rl.headers, 400);
+  }
   const encoded = encodeURIComponent(id);
 
   const result = await fetchYaci<YaciValidatorSigningStats[]>(

--- a/src/components/charts/gas-distribution-chart.tsx
+++ b/src/components/charts/gas-distribution-chart.tsx
@@ -44,6 +44,7 @@ export function GasDistributionChart({ data }: GasDistributionChartProps) {
           width={60}
         />
         <Tooltip
+          cursor={{ fill: "rgba(139, 92, 246, 0.08)" }}
           content={
             <ChartTooltip
               labelFormatter={(label) => `Gas: ${label}`}

--- a/src/components/charts/message-type-chart.tsx
+++ b/src/components/charts/message-type-chart.tsx
@@ -53,6 +53,7 @@ export function MessageTypeChart({ data }: MessageTypeChartProps) {
           width={120}
         />
         <Tooltip
+          cursor={{ fill: "rgba(139, 92, 246, 0.08)" }}
           content={
             <ChartTooltip
               labelFormatter={(label) => label}

--- a/src/components/dashboard/delegation-flow.tsx
+++ b/src/components/dashboard/delegation-flow.tsx
@@ -11,7 +11,7 @@ import { helpContent } from "@/lib/help-content";
 import { formatAmountShort, truncateAddress } from "@/lib/formatters";
 import { SearchInput } from "./search-input";
 
-const PAGE_SIZE = 10;
+const PAGE_SIZE = 20;
 
 export function DelegationFlow() {
   const [search, setSearch] = useState("");

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -354,10 +354,6 @@ export const ROLE_HIERARCHY: Record<string, number> = {
   admin: 4,
 };
 
-export const YACI_EXPLORER = {
-  baseUrl: "https://yaci-explorer-apis.fly.dev",
-} as const;
-
 export const CHART_COLORS = {
   primary: "#8B5CF6",
   secondary: "#D97706",

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -11,6 +11,10 @@ const envSchema = z.object({
     .length(64, "STREAM_TOKEN_SECRET must be 64 hex characters")
     .regex(/^[0-9a-f]+$/i, "STREAM_TOKEN_SECRET must be hex"),
   CRON_SECRET: z.string().min(1, "CRON_SECRET is required"),
+  YACI_EXPLORER_BASE_URL: z
+    .string()
+    .url()
+    .default("https://yaci-explorer-apis.fly.dev"),
 });
 
 /**

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,3 +1,5 @@
+import { addressToBytes } from "republic-sdk";
+
 export function parseIntParam(
   value: string | null | undefined,
   defaultValue: number,
@@ -33,4 +35,14 @@ export function parseDateParam(
   if (!value) return undefined;
   const date = new Date(value);
   return isNaN(date.getTime()) ? undefined : date;
+}
+
+export function isValidValoperAddress(id: string): boolean {
+  if (!id.startsWith("raivaloper1") || id.length > 100) return false;
+  try {
+    addressToBytes(id);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/src/lib/yaci.ts
+++ b/src/lib/yaci.ts
@@ -1,4 +1,4 @@
-import { YACI_EXPLORER } from "@/lib/constants";
+import { z } from "zod";
 import { logger } from "@/lib/logger";
 
 const TIMEOUT_MS = 12_000;
@@ -12,23 +12,35 @@ export type YaciResult<T> =
  * Returns a discriminated union so callers can distinguish
  * upstream errors from genuinely empty data.
  */
-export async function fetchYaci<T>(path: string, options?: { signal?: AbortSignal }): Promise<YaciResult<T>> {
+export async function fetchYaci<T>(
+  path: string,
+  options?: { signal?: AbortSignal; schema?: z.ZodType<T> },
+): Promise<YaciResult<T>> {
   try {
-    const res = await fetch(`${YACI_EXPLORER.baseUrl}${path}`, {
+    const baseUrl = process.env.YACI_EXPLORER_BASE_URL ?? "https://yaci-explorer-apis.fly.dev";
+    const res = await fetch(`${baseUrl}${path}`, {
       signal: options?.signal ?? AbortSignal.timeout(TIMEOUT_MS),
     });
     if (!res.ok) {
       logger.warn("yaci", `HTTP ${res.status} for ${path}`);
       return { ok: false, error: "http" };
     }
-    let data: T;
+    let raw: unknown;
     try {
-      data = (await res.json()) as T;
+      raw = await res.json();
     } catch {
       logger.warn("yaci", `JSON parse error for ${path}`);
       return { ok: false, error: "parse" };
     }
-    return { ok: true, data };
+    if (options?.schema) {
+      const parsed = options.schema.safeParse(raw);
+      if (!parsed.success) {
+        logger.warn("yaci", `Schema validation failed for ${path}: ${parsed.error.message}`);
+        return { ok: false, error: "parse" };
+      }
+      return { ok: true, data: parsed.data };
+    }
+    return { ok: true, data: raw as T };
   } catch (err) {
     // AbortSignal.timeout() throws TimeoutError in Node ≥18, AbortError in browsers/older Node
     const isTimeout =

--- a/tests/unit/api/validator-jailing.test.ts
+++ b/tests/unit/api/validator-jailing.test.ts
@@ -15,6 +15,13 @@ vi.mock("@/lib/yaci", () => ({
   fetchYaci: vi.fn(),
 }));
 
+vi.mock("republic-sdk", () => ({
+  addressToBytes: vi.fn((addr: string) => {
+    if (!addr.startsWith("raivaloper1")) throw new Error("Invalid bech32");
+    return new Uint8Array([1, 2, 3]);
+  }),
+}));
+
 import { fetchYaci } from "@/lib/yaci";
 
 describe("GET /api/validators/[id]/jailing", () => {
@@ -80,6 +87,17 @@ describe("GET /api/validators/[id]/jailing", () => {
     expect(res.status).toBe(502);
     expect(body.error).toMatch(/unavailable/i);
     expect(vi.mocked(fetchYaci)).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 400 for invalid validator address", async () => {
+    const { GET } = await import("@/app/api/validators/[id]/jailing/route");
+    const req = new NextRequest("http://localhost/api/validators/INVALID/jailing");
+    const res = await GET(req, { params: Promise.resolve({ id: "INVALID" }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/invalid/i);
+    expect(vi.mocked(fetchYaci)).not.toHaveBeenCalled();
   });
 
   it("returns empty array when validator has no consensus address", async () => {

--- a/tests/unit/api/validator-rewards.test.ts
+++ b/tests/unit/api/validator-rewards.test.ts
@@ -15,6 +15,13 @@ vi.mock("@/lib/yaci", () => ({
   fetchYaci: vi.fn(),
 }));
 
+vi.mock("republic-sdk", () => ({
+  addressToBytes: vi.fn((addr: string) => {
+    if (!addr.startsWith("raivaloper1")) throw new Error("Invalid bech32");
+    return new Uint8Array([1, 2, 3]);
+  }),
+}));
+
 import { fetchYaci } from "@/lib/yaci";
 
 describe("GET /api/validators/[id]/rewards", () => {
@@ -54,6 +61,17 @@ describe("GET /api/validators/[id]/rewards", () => {
 
     expect(res.status).toBe(502);
     expect(body.error).toMatch(/unavailable/i);
+  });
+
+  it("returns 400 for invalid validator address", async () => {
+    const { GET } = await import("@/app/api/validators/[id]/rewards/route");
+    const req = new NextRequest("http://localhost/api/validators/INVALID/rewards");
+    const res = await GET(req, { params: Promise.resolve({ id: "INVALID" }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/invalid/i);
+    expect(vi.mocked(fetchYaci)).not.toHaveBeenCalled();
   });
 
   it("returns empty array when no rewards", async () => {

--- a/tests/unit/api/validator-signing.test.ts
+++ b/tests/unit/api/validator-signing.test.ts
@@ -15,6 +15,13 @@ vi.mock("@/lib/yaci", () => ({
   fetchYaci: vi.fn(),
 }));
 
+vi.mock("republic-sdk", () => ({
+  addressToBytes: vi.fn((addr: string) => {
+    if (!addr.startsWith("raivaloper1")) throw new Error("Invalid bech32");
+    return new Uint8Array([1, 2, 3]);
+  }),
+}));
+
 import { fetchYaci } from "@/lib/yaci";
 
 describe("GET /api/validators/[id]/signing", () => {
@@ -62,6 +69,17 @@ describe("GET /api/validators/[id]/signing", () => {
 
     expect(res.status).toBe(502);
     expect(body.error).toMatch(/unavailable/i);
+  });
+
+  it("returns 400 for invalid validator address", async () => {
+    const { GET } = await import("@/app/api/validators/[id]/signing/route");
+    const req = new NextRequest("http://localhost/api/validators/INVALID/signing");
+    const res = await GET(req, { params: Promise.resolve({ id: "INVALID" }) });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/invalid/i);
+    expect(vi.mocked(fetchYaci)).not.toHaveBeenCalled();
   });
 
   it("returns null when yaci returns empty array", async () => {

--- a/tests/unit/lib/yaci.test.ts
+++ b/tests/unit/lib/yaci.test.ts
@@ -1,13 +1,26 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { z } from "zod";
 
 vi.mock("@/lib/logger", () => ({
   logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
 }));
 
 describe("yaci", () => {
+  const originalEnv = process.env.YACI_EXPLORER_BASE_URL;
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.restoreAllMocks();
+    vi.resetModules();
+    delete process.env.YACI_EXPLORER_BASE_URL;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.YACI_EXPLORER_BASE_URL = originalEnv;
+    } else {
+      delete process.env.YACI_EXPLORER_BASE_URL;
+    }
   });
 
   describe("fetchYaci", () => {
@@ -62,6 +75,59 @@ describe("yaci", () => {
       const result = await fetchYaci("/compute_stats");
 
       expect(result).toEqual({ ok: false, error: "timeout" });
+    });
+
+    it("uses custom base URL from YACI_EXPLORER_BASE_URL env", async () => {
+      process.env.YACI_EXPLORER_BASE_URL = "https://custom-yaci.example.com";
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: true }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { fetchYaci } = await import("@/lib/yaci");
+      await fetchYaci("/test-path");
+
+      expect(mockFetch.mock.calls[0][0]).toBe("https://custom-yaci.example.com/test-path");
+    });
+
+    it("uses default base URL when env is not set", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: true }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { fetchYaci } = await import("@/lib/yaci");
+      await fetchYaci("/test-path");
+
+      expect(mockFetch.mock.calls[0][0]).toBe("https://yaci-explorer-apis.fly.dev/test-path");
+    });
+
+    it("returns ok:false with error:'parse' when schema validation fails", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ unexpected: "data" }),
+      }));
+
+      const schema = z.object({ total_jobs: z.number() });
+      const { fetchYaci } = await import("@/lib/yaci");
+      const result = await fetchYaci("/test", { schema });
+
+      expect(result).toEqual({ ok: false, error: "parse" });
+    });
+
+    it("validates data with schema when provided", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ total_jobs: 42 }),
+      }));
+
+      const schema = z.object({ total_jobs: z.number() });
+      const { fetchYaci } = await import("@/lib/yaci");
+      const result = await fetchYaci("/test", { schema });
+
+      expect(result).toEqual({ ok: true, data: { total_jobs: 42 } });
     });
 
     it("returns ok:false with error:'parse' on invalid JSON", async () => {


### PR DESCRIPTION
## Summary
- **Yaci URL → env variable:** `YACI_EXPLORER_BASE_URL` with Zod validation and safe default — no Vercel env change needed
- **Bech32 validator address guard:** 3 Yaci proxy routes now reject invalid `raivaloper1` addresses (400) using real checksum validation via `addressToBytes()` from republic-sdk
- **fetchYaci Zod schema support:** Optional `schema` parameter for runtime response validation (backward compatible)
- **Chart hover fix:** Subtle purple cursor on Gas Distribution and Message Type bar charts
- **Delegation page size:** 10 → 20 items per page

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 1316/1316 passed (+7 new tests)
- [ ] Manual: verify chart hover on Gas Distribution & Message Types
- [ ] Manual: verify delegation pagination shows 20 items
- [ ] Manual: confirm `/api/validators/INVALID/signing` returns 400